### PR TITLE
Phase dependencies

### DIFF
--- a/ORBIT/core/exceptions.py
+++ b/ORBIT/core/exceptions.py
@@ -386,3 +386,24 @@ class FastenTimeNotFound(Exception):
 
     def __str__(self):
         return self.message
+
+
+class PhaseDependenciesInvalid(Exception):
+    """Error for phase dependencies that can't be resolved."""
+
+    def __init__(self, phases):
+        """
+        Creates an instance of PhaseDependenciesInvalid.
+
+        Parameters
+        ----------
+        phases : dict
+            Invalid phases.
+        """
+
+        self.phases = phases
+
+        self.message = f"Phase dependencies {phases} are not resolvable."
+
+    def __str__(self):
+        return self.message

--- a/ORBIT/manager.py
+++ b/ORBIT/manager.py
@@ -33,7 +33,11 @@ from ORBIT.phases.install import (
     ScourProtectionInstallation,
     OffshoreSubstationInstallation,
 )
-from ORBIT.core.exceptions import PhaseNotFound, WeatherProfileError
+from ORBIT.core.exceptions import (
+    PhaseNotFound,
+    WeatherProfileError,
+    PhaseDependenciesInvalid,
+)
 
 
 class ProjectManager:
@@ -607,14 +611,22 @@ class ProjectManager:
                     continue
 
             if phases and progress is False:
-                raise Exception("")
+                raise PhaseDependenciesInvalid(phases)
 
             else:
                 break
 
     def get_dependency_start_time(self, target, perc):
         """
+        Returns start time based on the `perc` complete of `target` phase.
 
+        Parameters
+        ----------
+        target : str
+            Phase that start time is dependent on.
+        perc : int | float
+            Percentage of the target phase completion time. `0`: starts at the
+            same time. `1`: starts when target phase is completed.
         """
 
         start = self.phase_starts[target]

--- a/ORBIT/manager.py
+++ b/ORBIT/manager.py
@@ -84,8 +84,9 @@ class ProjectManager:
             ],
         )
         self.config = self.resolve_project_capacity(config)
+        self.weather = self.transform_weather_input(weather)
 
-        self.weather = weather
+        self.phase_starts = {}
         self.phase_times = {}
         self.phase_costs = {}
         self._output_logs = []
@@ -361,7 +362,7 @@ class ProjectManager:
 
         return phase_config
 
-    def run_install_phase(self, name, weather, **kwargs):
+    def run_install_phase(self, name, start, **kwargs):
         """
         Compiles the phase specific configuration input dictionary for input
         'name', checks the input against _class.expected_config and runs the
@@ -382,6 +383,12 @@ class ProjectManager:
         logs : list
             List of phase logs.
         """
+
+        if self.weather is not None:
+            weather = self.get_weather_profile(start)
+
+        else:
+            weather = None
 
         _catch = kwargs.get("catch_exceptions", False)
         _class = self.get_phase_class(name)
@@ -413,6 +420,7 @@ class ProjectManager:
         cost = phase.total_phase_cost
         logs = deepcopy(phase.env.logs)
 
+        self.phase_starts[name] = start
         self.phase_costs[name] = cost
         self.phase_times[name] = time
         self.detailed_outputs = self.merge_dicts(
@@ -507,16 +515,10 @@ class ProjectManager:
             List of installation phases to run.
         """
 
-        _start = 0
+        start = 0
 
         for name in phase_list:
-            if self.weather is not None:
-                weather = self.weather.iloc[ceil(_start) :].copy().to_records()
-
-            else:
-                weather = None
-
-            time, cost, logs = self.run_install_phase(name, weather, **kwargs)
+            time, cost, logs = self.run_install_phase(name, start, **kwargs)
 
             if logs is None:
                 continue
@@ -524,39 +526,31 @@ class ProjectManager:
             else:
                 for l in logs:
                     try:
-                        l["time"] += _start
+                        l["time"] += start
                     except KeyError:
                         pass
 
                 self._output_logs.extend(logs)
-                _start = ceil(_start + time)
+                start = ceil(start + time)
 
-    def run_multiple_phases_overlapping(self, phase_dict, **kwargs):
+    def run_multiple_phases_overlapping(self, phases, **kwargs):
         """
-        Runs multiple phases with defined start days in
-        self.config['install_phases'].
+        Runs multiple phases overlapping using a mixture of dates, indices or
+        dependencies.
 
         Parameters
         ----------
-        phase_dict : dict
-            Dictionary of phases to run with keys that indicate start date.
+        phases : dict
+            Dictionary of phases to run.
         """
 
-        start_dates = {
-            k: dt.datetime.strptime(v, self.date_format_short)
-            for k, v in phase_dict.items()
-        }
+        defined, variable = self._parse_install_phase_values(phases)
+        zero = min(defined.values())
 
-        _zero = min(start_dates.values())
+        # Run defined
+        for name, start in defined.items():
 
-        for name, start in start_dates.items():
-            if self.weather is not None:
-                weather = self.get_weather_profile(start)
-
-            else:
-                weather = None
-
-            time, cost, logs = self.run_install_phase(name, weather, **kwargs)
+            time, cost, logs = self.run_install_phase(name, start, **kwargs)
 
             if logs is None:
                 continue
@@ -564,11 +558,146 @@ class ProjectManager:
             else:
                 for l in logs:
                     try:
-                        l["time"] += (start - _zero).days * 24
+                        l["time"] += start - zero
                     except KeyError:
                         pass
 
                 self._output_logs.extend(logs)
+
+        # Run remaining phases
+        self.run_dependent_phases(variable, zero)
+
+    def run_dependent_phases(self, phases, zero, **kwargs):
+        """
+        Runs remaining phases that depend on other phase times.
+
+        Parameters
+        ----------
+        phases : dict
+            Dictionary of phases to run.
+        zero : int | float
+            Zero time for the simulation. Used to aggregate total logs.
+        """
+
+        while True:
+
+            progress = False
+            for name, (target, perc) in phases.items():
+
+                try:
+                    start = self.get_dependency_start_time(target, perc)
+                    time, cost, logs = self.run_install_phase(
+                        name, start, **kwargs
+                    )
+                    progress = True
+
+                    if logs is None:
+                        continue
+
+                    else:
+                        for l in logs:
+                            try:
+                                l["time"] += start - zero
+                            except KeyError:
+                                pass
+
+                        self._output_logs.extend(logs)
+
+                except KeyError:
+                    continue
+
+            if phases and progress is False:
+                raise Exception("")
+
+            else:
+                break
+
+    def get_dependency_start_time(self, target, perc):
+        """
+
+        """
+
+        start = self.phase_starts[target]
+        elapsed = self.phase_times[target]
+
+        return start + elapsed * perc
+
+    @staticmethod
+    def transform_weather_input(weather):
+        """
+        Checks that an input weather profile matches the required format and
+        converts the index to a datetime index if necessary.
+
+        Parameters
+        ----------
+        weather : pd.DataFrame
+        """
+
+        if weather is None:
+            return None
+
+        else:
+            try:
+                weather = weather.set_index("datetime")
+                if not isinstance(weather.index, pd.DatetimeIndex):
+                    weather.index = pd.to_datetime(weather.index)
+
+            except KeyError:
+                pass
+
+            return weather
+
+    def _parse_install_phase_values(self, phases):
+        """
+        Parses the input dictionary `install_phases`, splitting them into
+        phases that have defined start times and ones that rely on other phases.
+
+        Parameters
+        ----------
+        phases : dict
+            Dictionary of installation phases to run.
+
+        Raises
+        ------
+        ValueError
+            Raised if no phases have a defined start date as the project can't
+            be tied to a specific part of the weather profile.
+        """
+
+        defined = {}
+        depends = {}
+
+        for k, v in phases.items():
+
+            if isinstance(v, (int, float)):
+                defined[k] = ceil(v)
+
+            elif isinstance(v, str):
+                _dt = dt.datetime.strptime(v, self.date_format_short)
+
+                try:
+                    i = self.weather.index.get_loc(_dt)
+                    defined[k] = i
+
+                except AttributeError:
+                    raise ValueError(
+                        f"No weather profile configured "
+                        f"for '{k}': '{v}' input type."
+                    )
+
+                except KeyError:
+                    raise WeatherProfileError(_dt, self.weather)
+
+            elif isinstance(v, tuple) and len(v) == 2:
+                depends[k] = v
+
+            else:
+                raise ValueError(f"Input type '{k}': '{v}' not recognized.")
+
+        if not defined:
+            raise ValueError("No phases have a defined start index/date.")
+
+        return defined, depends
 
     def get_weather_profile(self, start):
         """
@@ -586,15 +715,7 @@ class ProjectManager:
             Weather profile with first index at 'start'.
         """
 
-        if not isinstance(self.weather.index, pd.DatetimeIndex):
-            self.weather.index = pd.to_datetime(self.weather.index)
-
-        profile = self.weather.loc[start:].copy()
-
-        if profile.empty:
-            raise WeatherProfileError(start, self.weather)
-
-        return profile.to_records()
+        return self.weather.iloc[ceil(start) :].copy().to_records()
 
     @property
     def capacity(self):

--- a/tests/data/library/project/config/project_manager.yaml
+++ b/tests/data/library/project/config/project_manager.yaml
@@ -12,6 +12,7 @@ monopile:
   mass: 350
 plant:
   num_turbines: 10
+  turbine_spacing: 7
 port:
   monthly_rate: 10000
   num_cranes: 1
@@ -33,4 +34,5 @@ turbine:
     deck_space: 100
     mass: 400
     length: 100
+  rotor_diameter: 120
 wtiv: test_wtiv

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -25,6 +25,20 @@ initialize_library(pytest.library)
 config = extract_library_specs("config", "project_manager")
 
 
+### Top Level
+@pytest.mark.parametrize("weather", (None, weather_df))
+def test_complete_run(weather):
+
+    project = ProjectManager(config, weather=weather)
+    project.run_project()
+
+    actions = pd.DataFrame(project.project_actions)
+
+    phases = ["MonopileInstallation", "TurbineInstallation"]
+    assert all(p in list(actions["phase"]) for p in phases)
+
+
+### Module Integrations
 def test_for_required_phase_structure():
     """
     Automated integration test to verify that all classes listed in
@@ -41,33 +55,10 @@ def test_for_required_phase_structure():
         assert isinstance(p.output_config, dict)
 
 
-def test_exceptions():
-
-    incomplete_config = deepcopy(config)
-    _ = incomplete_config["site"].pop("depth")
-
-    with pytest.raises(MissingInputs):
-        project = ProjectManager(incomplete_config)
-        project.run_project()
-
-    wrong_phases = deepcopy(config)
-    wrong_phases["install_phases"].append("IncorrectPhaseName")
-
-    with pytest.raises(PhaseNotFound):
-        project = ProjectManager(wrong_phases)
-        project.run_project()
-
-    bad_dates = deepcopy(config)
-    bad_dates["install_phases"] = {
-        "MonopileInstallation": "03/01/2015",
-        "TurbineInstallation": "05/01/2015",
-    }
-
-    with pytest.raises(WeatherProfileError):
-        project = ProjectManager(bad_dates, weather=weather_df)
-        project.run_project()
+# TODO: Expand these tests
 
 
+### Config Management
 def test_phase_specific_definitions():
     """
     Tests that phase specific information makes it to phase_config.
@@ -116,139 +107,6 @@ def test_expected_config_merging():
     }
 
 
-@pytest.mark.parametrize("weather", (None, weather_df))
-def test_complete_run(weather):
-
-    project = ProjectManager(config, weather=weather)
-    project.run_project()
-
-    actions = pd.DataFrame(project.project_actions)
-
-    phases = ["MonopileInstallation", "TurbineInstallation"]
-    assert all(p in list(actions["phase"]) for p in phases)
-
-
-@pytest.mark.parametrize(
-    "m_start, t_start",
-    [
-        ("03/01/2010", "03/01/2010"),
-        ("03/01/2010", "04/01/2010"),
-        ("03/01/2010", "05/01/2010"),
-        ("04/01/2010", "06/01/2010"),
-    ],
-)
-def test_phase_start_dates(m_start, t_start):
-    """
-    Tests functionality related to passing start dates into 'install_phases' sub-dict.
-    """
-    config_with_start_dates = deepcopy(config)
-    config_with_start_dates["install_phases"] = {
-        "MonopileInstallation": m_start,
-        "TurbineInstallation": t_start,
-    }
-
-    project = ProjectManager(config_with_start_dates)
-    project.run_project()
-
-    df = pd.DataFrame(project.project_actions)
-    _fmt = "%m/%d/%Y"
-    _target_diff = (
-        datetime.strptime(t_start, _fmt) - datetime.strptime(m_start, _fmt)
-    ).days * 24
-
-    _m = df.loc[df["phase"] == "MonopileInstallation"].iloc[0]
-    _t = df.loc[df["phase"] == "TurbineInstallation"].iloc[0]
-
-    _diff = (_t["time"] - _t["duration"]) - (_m["time"] - _m["duration"])
-    assert _diff == _target_diff
-
-
-def test_phase_start_dates_with_weather():
-    m_start = "03/01/2010"
-    t_start = "05/01/2010"
-
-    config_with_start_dates = deepcopy(config)
-    config_with_start_dates["install_phases"] = {
-        "MonopileInstallation": m_start,
-        "TurbineInstallation": t_start,
-    }
-
-    project = ProjectManager(config_with_start_dates, weather=weather_df)
-    project.run_project()
-
-    df = pd.DataFrame(project.project_actions)
-    _fmt = "%m/%d/%Y"
-    _target_diff = (
-        datetime.strptime(t_start, _fmt) - datetime.strptime(m_start, _fmt)
-    ).days * 24
-
-    _m = df.loc[df["phase"] == "MonopileInstallation"].iloc[0]
-    _t = df.loc[df["phase"] == "TurbineInstallation"].iloc[0]
-
-    _diff = (_t["time"] - _t["duration"]) - (_m["time"] - _m["duration"])
-    assert _diff == _target_diff
-
-
-def test_duplicate_phase_simulations():
-    config_with_duplicates = deepcopy(config)
-    config_with_duplicates["MonopileInstallation_1"] = {
-        "plant": {"num_turbines": 5}
-    }
-
-    config_with_duplicates["MonopileInstallation_2"] = {
-        "plant": {"num_turbines": 5},
-        "site": {"distance": 100},
-    }
-
-    config_with_duplicates["install_phases"] = {
-        "MonopileInstallation_1": "03/01/2010",
-        "MonopileInstallation_2": "04/01/2010",
-        "TurbineInstallation": "05/01/2010",
-    }
-
-    project = ProjectManager(config_with_duplicates)
-    project.run_project()
-
-    df = (
-        pd.DataFrame(project.project_actions)
-        .groupby(["phase", "action"])
-        .count()["time"]
-    )
-
-    assert df.loc[("MonopileInstallation_1", "Drive Monopile")] == 5
-    assert df.loc[("MonopileInstallation_2", "Drive Monopile")] == 5
-    assert df.loc[("TurbineInstallation", "Attach Tower Section")] == 10
-
-
-def test_design_phases():
-
-    config_with_design = deepcopy(config)
-
-    # Add MonopileDesign
-    config_with_design["design_phases"] = ["MonopileDesign"]
-
-    # Add required parameters
-    config_with_design["site"]["mean_windspeed"] = 9
-    config_with_design["turbine"]["rotor_diameter"] = 200
-    config_with_design["turbine"]["rated_windspeed"] = 10
-    config_with_design["monopile_design"] = {}
-
-    # Remove monopile sub dictionary
-    _ = config_with_design.pop("monopile")
-    project = ProjectManager(config_with_design)
-    project.run_project()
-
-    assert isinstance(project.config["monopile"], dict)
-
-    config_with_design["install_phases"] = {
-        "MonopileInstallation": "03/01/2010",
-        "TurbineInstallation": "05/01/2010",
-    }
-
-    project = ProjectManager(config_with_design, weather=weather_df)
-    project.run_project()
-
-
 def test_find_key_match():
     class SpecificTurbineInstallation:
         expected_config = {}
@@ -288,6 +146,140 @@ def test_find_key_match():
         assert TestProjectManager.find_key_match(f) is None
 
 
+### Overlapping Install Phases
+def test_install_phase_start_parsing():
+
+    config_mixed_starts = deepcopy(config)
+    config_mixed_starts["install_phases"] = {
+        "MonopileInstallation": 0,
+        "TurbineInstallation": "10/22/2009",
+        "ArrayCableInstallation": {"MonopileInstallation": 0.5},
+    }
+
+    project = ProjectManager(config_mixed_starts, weather=weather_df)
+    defined, depends = project._parse_install_phase_values(
+        config_mixed_starts["install_phases"]
+    )
+    assert len(defined) == 2
+    assert len(depends) == 1
+
+    assert defined["MonopileInstallation"] == 0
+    assert defined["TurbineInstallation"] == 1
+
+
+@pytest.mark.parametrize(
+    "m_start, t_start", [(0, 0), (0, 100), (100, 100), (100, 200)]
+)
+def test_index_starts(m_start, t_start):
+    """
+    Tests functionality related to passing index starts into 'install_phases' sub-dict.
+    """
+    _target_diff = t_start - m_start
+
+    config_with_index_starts = deepcopy(config)
+    config_with_index_starts["install_phases"] = {
+        "MonopileInstallation": m_start,
+        "TurbineInstallation": t_start,
+    }
+
+    project = ProjectManager(config_with_index_starts)
+    project.run_project()
+
+    df = pd.DataFrame(project.project_actions)
+
+    _m = df.loc[df["phase"] == "MonopileInstallation"].iloc[0]
+    _t = df.loc[df["phase"] == "TurbineInstallation"].iloc[0]
+
+    _diff = (_t["time"] - _t["duration"]) - (_m["time"] - _m["duration"])
+    assert _diff == _target_diff
+
+
+@pytest.mark.parametrize(
+    "m_start, t_start, expected",
+    [
+        (0, 0, 0),
+        (0, 1000, 1000),
+        (0, "05/01/2010", 4585),
+        ("03/01/2010", "03/01/2010", 0),
+        ("03/01/2010", "05/01/2010", 1464),
+    ],
+)
+def test_start_dates_with_weather(m_start, t_start, expected):
+
+    config_with_defined_starts = deepcopy(config)
+    config_with_defined_starts["install_phases"] = {
+        "MonopileInstallation": m_start,
+        "TurbineInstallation": t_start,
+    }
+
+    project = ProjectManager(config_with_defined_starts, weather=weather_df)
+    project.run_project()
+    df = pd.DataFrame(project.project_actions)
+
+    _m = df.loc[df["phase"] == "MonopileInstallation"].iloc[0]
+    _t = df.loc[df["phase"] == "TurbineInstallation"].iloc[0]
+
+    _diff = (_t["time"] - _t["duration"]) - (_m["time"] - _m["duration"])
+    assert _diff == expected
+
+
+def test_duplicate_phase_definitions():
+    config_with_duplicates = deepcopy(config)
+    config_with_duplicates["MonopileInstallation_1"] = {
+        "plant": {"num_turbines": 5}
+    }
+
+    config_with_duplicates["MonopileInstallation_2"] = {
+        "plant": {"num_turbines": 5},
+        "site": {"distance": 100},
+    }
+
+    config_with_duplicates["install_phases"] = {
+        "MonopileInstallation_1": 0,
+        "MonopileInstallation_2": 800,
+        "TurbineInstallation": 1600,
+    }
+
+    project = ProjectManager(config_with_duplicates)
+    project.run_project()
+
+    df = (
+        pd.DataFrame(project.project_actions)
+        .groupby(["phase", "action"])
+        .count()["time"]
+    )
+
+    assert df.loc[("MonopileInstallation_1", "Drive Monopile")] == 5
+    assert df.loc[("MonopileInstallation_2", "Drive Monopile")] == 5
+    assert df.loc[("TurbineInstallation", "Attach Tower Section")] == 10
+
+
+### Design Phase Interactions
+def test_design_phases():
+
+    config_with_design = deepcopy(config)
+
+    # Add MonopileDesign
+    config_with_design["design_phases"] = ["MonopileDesign"]
+
+    # Add required parameters
+    config_with_design["site"]["mean_windspeed"] = 9
+    config_with_design["turbine"]["rotor_diameter"] = 200
+    config_with_design["turbine"]["rated_windspeed"] = 10
+    config_with_design["monopile_design"] = {}
+
+    # Remove monopile sub dictionary
+    _ = config_with_design.pop("monopile")
+    project = ProjectManager(config_with_design)
+    project.run_project()
+
+    assert isinstance(project.config["monopile"], dict)
+
+    project = ProjectManager(config_with_design)
+    project.run_project()
+
+
+### Outputs
 def test_resolve_project_capacity():
 
     # Missing turbine rating
@@ -357,3 +349,31 @@ def test_resolve_project_capacity():
 
     with pytest.raises(KeyError):
         num_turbines = out6["plant"]["num_turbines"]
+
+
+### Exceptions
+def test_exceptions():
+
+    incomplete_config = deepcopy(config)
+    _ = incomplete_config["site"].pop("depth")
+
+    with pytest.raises(MissingInputs):
+        project = ProjectManager(incomplete_config)
+        project.run_project()
+
+    wrong_phases = deepcopy(config)
+    wrong_phases["install_phases"].append("IncorrectPhaseName")
+
+    with pytest.raises(PhaseNotFound):
+        project = ProjectManager(wrong_phases)
+        project.run_project()
+
+    bad_dates = deepcopy(config)
+    bad_dates["install_phases"] = {
+        "MonopileInstallation": "03/01/2015",
+        "TurbineInstallation": "05/01/2015",
+    }
+
+    with pytest.raises(WeatherProfileError):
+        project = ProjectManager(bad_dates, weather=weather_df)
+        project.run_project()


### PR DESCRIPTION
This PR adds the ability to have phases depend on the start and elapsed time of a different phase.

Example configs:

```
config = {
    ...

    "install_phases" = {
        "MonopileInstallation": 0  # Start at index 0, alternatively you could define a start date "01/01/2010"
        "TurbineInstallation": ("MonopileInstallation", 0.5)  # Will start when MonopileInstallation is 50% complete
    }
}
```

They can be chained:
```
config = {
    ...

    "install_phases" = {
        "ScourProtectionInstallation": 0
        "MonopileInstallation": ("ScourProtectionInstallation", 0.1) 
        "TurbineInstallation": ("MonopileInstallation", 0.5)
    }
}
```

Will raise an error that they aren't resolvable because of the circular dependency:
```
config = {
    ...

    "install_phases" = {
        "ScourProtectionInstallation": 0
        "MonopileInstallation": ("TurbineInstallation", 0.1) 
        "TurbineInstallation": ("MonopileInstallation", 0.5)
    }
}
```

One thing to note: this is based on the elapsed time of the phase, not exactly "% substructures installed" or "% array cable installed". I can modify if necessary but this is the easiest implementation and in my opinion is sufficient.