### PR TITLE
Windspeed constraints @ multiple heights

### DIFF
--- a/ORBIT/core/__init__.py
+++ b/ORBIT/core/__init__.py
@@ -10,3 +10,4 @@ from .port import Port
 from .cargo import Cargo
 from .vessel import Vessel
 from .components import Crane, JackingSys
+from .environment import OrbitEnvironment as Environment

--- a/ORBIT/core/environment.py
+++ b/ORBIT/core/environment.py
@@ -176,8 +176,12 @@ class OrbitEnvironment(Environment):
 
         heights = []
         for c in columns:
-            val = c.split("_")[1].replace("m", "")
-            heights.append(float(val) if "." in val else int(val))
+            try:
+                val = c.split("_")[1].replace("m", "")
+                heights.append(float(val) if "." in val else int(val))
+
+            except IndexError:
+                pass
 
         return sorted(heights)
 

--- a/ORBIT/core/environment.py
+++ b/ORBIT/core/environment.py
@@ -199,7 +199,7 @@ class OrbitEnvironment(Environment):
         ts1 = self.state[f"windspeed_{h1}m"]
         ts2 = self.state[f"windspeed_{h2}m"]
         alpha = np.log(ts2.mean() / ts1.mean()) / np.log(h2 / h1)
-        print(alpha)
+
         ts = ts1 * (h / h1) ** alpha
 
         self.state = np.array(append_fields(self.state, f"windspeed_{h}m", ts))
@@ -218,11 +218,7 @@ class OrbitEnvironment(Environment):
         """
 
         ts1 = self.state[f"windspeed_{h1}m"]
-        if h > h1:
-            ts = ts1 * (h / h1) ** self.alpha
-
-        else:
-            ts = ts1 / ((h1 / h) ** self.alpha)
+        ts = ts1 * (h / h1) ** self.alpha
 
         self.state = np.array(append_fields(self.state, f"windspeed_{h}m", ts))
 

--- a/ORBIT/core/environment.py
+++ b/ORBIT/core/environment.py
@@ -1,0 +1,77 @@
+"""ORBIT specific marmot.Environment."""
+
+__author__ = "Jake Nunemaker"
+__copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
+__maintainer__ = "Jake Nunemaker"
+__email__ = "jake.nunemaker@nrel.gov"
+
+
+from marmot import Environment
+from marmot._core import Constraint
+
+
+class OrbitEnvironment(Environment):
+    """ORBIT Specific Environment."""
+
+    def _find_valid_constraints(self, **kwargs):
+        """
+        Finds any constraitns in `kwargs` where the key matches a column name
+        in `self.state` and the value type is `Constraint`.
+
+        This method overrides the default method to handle windspeed
+        constraints specifically, interpolating or extrapolating environment
+        windspeed profiles to the input constraint height.
+
+        Returns
+        -------
+        valid : dict
+            Valid constraints that apply to a column in `self.state`.
+        """
+
+        _constraints = {
+            k: v for k, v in kwargs.items() if isinstance(v, Constraint)
+        }
+        ws = {}
+        valid = {}
+
+        for k, v in _constraints.items():
+            if "windspeed" in k:
+                ws[k] = v
+
+            elif k in self.state.dtype.names:
+                valid[k] = v
+
+        valid = {**valid, **self.resolve_windspeed_constraints(ws)}
+        return valid
+
+    def resolve_windspeed_constraints(self, ws):
+        """
+        Resolves the applied windspeed constraints given the windspeed profiles
+        that are present in `self.state`.
+
+        Parameters
+        ----------
+        ws : dict
+            Windspeed constraints in the format: `'windspeed_###m': Constraint`
+
+        Returns
+        -------
+        valid_ws : dict
+            Valid windspeed constraints.
+        """
+
+        if "windspeed" in self.state.dtype.names:
+            if len(ws) > 1:
+                raise ValueError(
+                    "Multiple windspeed constraints applied to "
+                    "the 'windspeed' column."
+                )
+
+            return {"windspeed": v for _, v in ws.items()}
+
+    @property
+    def windspeed_heights(self):
+        """Returns heights of available windspeed profiles."""
+
+        columns = [c for c in self.state.dtype.names if "windspeed" in c]
+        return [float(c.split("_")[1].replace("m", "")) for c in columns]

--- a/ORBIT/phases/install/install_phase.py
+++ b/ORBIT/phases/install/install_phase.py
@@ -43,7 +43,7 @@ class InstallPhase(BasePhase):
         """
 
         env_name = kwargs.get("env_name", "Environment")
-        self.env = Environment(name=env_name, state=weather)
+        self.env = Environment(name=env_name, state=weather, **kwargs)
 
     @abstractmethod
     def setup_simulation(self):

--- a/ORBIT/phases/install/install_phase.py
+++ b/ORBIT/phases/install/install_phase.py
@@ -12,9 +12,8 @@ from itertools import groupby
 import numpy as np
 import simpy
 
-from ORBIT.core import Port
+from ORBIT.core import Port, Environment
 from ORBIT.phases import BasePhase
-from ORBIT.core.environment import OrbitEnvironment as Environment
 
 
 class InstallPhase(BasePhase):

--- a/ORBIT/phases/install/install_phase.py
+++ b/ORBIT/phases/install/install_phase.py
@@ -11,10 +11,10 @@ from itertools import groupby
 
 import numpy as np
 import simpy
-from marmot import Environment
 
 from ORBIT.core import Port
 from ORBIT.phases import BasePhase
+from ORBIT.core.environment import OrbitEnvironment as Environment
 
 
 class InstallPhase(BasePhase):

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -1,0 +1,116 @@
+"""Tests for the `Vessel` class."""
+
+__author__ = "Jake Nunemaker"
+__copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
+__maintainer__ = "Jake Nunemaker"
+__email__ = "jake.nunemaker@nrel.gov"
+
+import pandas as pd
+import pytest
+from marmot import le
+
+from ORBIT.core import Environment
+from tests.data import test_weather as _weather
+
+# Weather data with 'windspeed' column
+simple_weather = _weather.copy()
+
+# Weather data with windspeed heights and complex varied column name precision
+weather = pd.DataFrame(_weather)
+weather["windspeed_10m"] = weather["windspeed"].copy()
+weather = weather.drop("windspeed", axis=1)
+weather["windspeed_100.0m"] = weather["windspeed_10m"].copy() * 1.3
+weather["windspeed_1.2m"] = weather["windspeed_10m"].copy() * 0.7
+weather = weather.to_records()
+
+
+def test_simple_inputs():
+    env = Environment(state=simple_weather)
+
+    assert "waveheight" in env.state.dtype.names
+    assert "windspeed" in env.state.dtype.names
+
+
+def test_inputs():
+    env = Environment(state=weather)
+
+    assert "waveheight" in env.state.dtype.names
+    assert "windspeed" not in env.state.dtype.names
+    assert "windspeed_10m" in env.state.dtype.names
+    assert "windspeed_100m" in env.state.dtype.names
+    assert "windspeed_1.2m" in env.state.dtype.names
+
+    env2 = Environment(state=weather, ws_alpha=0.12, ws_default_height=20)
+
+    assert env2.alpha == 0.12
+    assert env2.default_height == 20
+
+
+def test_simple_constraint_application():
+    env = Environment(state=simple_weather)
+
+    constraints = {"windspeed": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert valid == constraints
+
+    with_height = {"windspeed_100m": le(10)}
+    valid = env._find_valid_constraints(**with_height)
+    assert "windspeed" in list(valid.keys())
+
+    with_mult_heights = {"windspeed_100m": le(10), "windspeed_10m": le(8)}
+    with pytest.raises(ValueError):
+        valid = env._find_valid_constraints(**with_mult_heights)
+
+
+def test_constraint_application():
+    env = Environment(state=weather)
+
+    constraints = {"waveheight": le(2), "windspeed": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert "windspeed_10m" in list(valid.keys())
+
+    constraints = {"waveheight": le(2), "windspeed_10m": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert "waveheight" in list(valid.keys())
+    assert "windspeed_10m" in list(valid.keys())
+
+    assert "windspeed_20m" not in env.state.dtype.names
+    constraints = {"waveheight": le(2), "windspeed_20m": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert "windspeed_20m" in list(valid.keys())
+    assert "windspeed_20m" in env.state.dtype.names
+
+    assert "windspeed_120m" not in env.state.dtype.names
+    constraints = {"waveheight": le(2), "windspeed_120m": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert "windspeed_120m" in list(valid.keys())
+    assert "windspeed_120m" in env.state.dtype.names
+
+
+def test_interp():
+    env = Environment(state=weather)
+
+    assert "windspeed_20m" not in env.state.dtype.names
+    constraints = {"waveheight": le(2), "windspeed_20m": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert "windspeed_20m" in env.state.dtype.names
+    assert (env.state["windspeed_10m"] < env.state["windspeed_20m"]).all()
+    assert (env.state["windspeed_20m"] < env.state["windspeed_100m"]).all()
+
+
+def test_extrap():
+    env = Environment(state=weather)
+
+    assert "windspeed_120m" not in env.state.dtype.names
+    constraints = {"waveheight": le(2), "windspeed_120m": le(10)}
+    valid = env._find_valid_constraints(**constraints)
+    assert "windspeed_120m" in env.state.dtype.names
+    assert (env.state["windspeed_120m"] > env.state["windspeed_100m"]).all()
+
+    env2 = Environment(state=weather, ws_alpha=0.12)
+
+    assert "windspeed_120m" not in env2.state.dtype.names
+    constraints = {"waveheight": le(2), "windspeed_120m": le(10)}
+    valid = env2._find_valid_constraints(**constraints)
+    assert (env.state["windspeed_100m"] == env2.state["windspeed_100m"]).all()
+    assert (env.state["windspeed_120m"] < env2.state["windspeed_120m"]).all()


### PR DESCRIPTION
This allows the user to define wind speed constraints at different hub heights. The newly created `OrbitEnvironment` automatically handles any interpolation/extrapolation that is needed.

@Matt-Shields I implemented this in a way that it won't impact our current workflows and the addition of heights for ws constraints is optional.

A few important notes:
- If a generic "windspeed" column is included in the weather profile, all constraints (regardless of height) will be compared against this time series.
- If different windspeed heights are desired, weather data can be passed in with columns like: "windspeed_100m", or "windspeed_10.0m". If a constraint calls for "windspeed_50m", a new time series will be interpolated using the power law. If a constraint calls for "windspeed_120m", a time series will be extrapolated from "windspeed_100m" and an assumed alpha (default: 0.1, kwarg: "ws_alpha")
- If the loaded time series have heights associated with them and a generic constraint is applied ("windspeed"), the default height (10m) will be used. Can be overridden with kwarg: "ws_default_height"

