### PR TITLE
checking for equals on strings with 'is' fails on some pythons

### DIFF
--- a/ORBIT/phases/install/monopile_install/common.py
+++ b/ORBIT/phases/install/monopile_install/common.py
@@ -337,10 +337,10 @@ def install_transition_piece(vessel, tp, **kwargs):
     )
     yield lower_transition_piece(vessel, **kwargs)
 
-    if connection is "bolted":
+    if connection == "bolted":
         yield bolt_transition_piece(vessel, **kwargs)
 
-    elif connection is "grouted":
+    elif connection == "grouted":
 
         yield pump_transition_piece_grout(vessel, **kwargs)
         yield cure_transition_piece_grout(vessel)

--- a/ORBIT/phases/install/oss_install/common.py
+++ b/ORBIT/phases/install/oss_install/common.py
@@ -135,10 +135,10 @@ def install_topside(vessel, topside, **kwargs):
     yield lift_topside(vessel)
     yield attach_topside(vessel)
 
-    if connection is "bolted":
+    if connection == "bolted":
         yield bolt_transition_piece(vessel, **kwargs)
 
-    elif connection is "grouted":
+    elif connection == "grouted":
 
         yield pump_transition_piece_grout(vessel, **kwargs)
         yield cure_transition_piece_grout(vessel, **kwargs)


### PR DESCRIPTION
Some windows python installations fail on these lines.