### PR TITLE
Added availability option for vessels.

### DIFF
--- a/ORBIT/core/logic/vessel_logic.py
+++ b/ORBIT/core/logic/vessel_logic.py
@@ -40,7 +40,7 @@ def prep_for_site_operations(vessel, survey_required=False, **kwargs):
 
     if survey_required:
         survey_time = kwargs.get("rov_survey_time", pt["rov_survey_time"])
-        yield vessel.task(
+        yield vessel.task_wrapper(
             "RovSurvey",
             survey_time,
             constraints=vessel.transit_limits,
@@ -74,7 +74,7 @@ def stabilize(vessel, **kwargs):
         site_depth = kwargs.get("site_depth", 40)
         extension = kwargs.get("extension", site_depth + 10)
         jackup_time = jacksys.jacking_time(extension, site_depth)
-        yield vessel.task(
+        yield vessel.task_wrapper(
             "Jackup", jackup_time, constraints=vessel.transit_limits, **kwargs
         )
 
@@ -102,7 +102,7 @@ def jackdown_if_required(vessel, **kwargs):
         site_depth = kwargs.get("site_depth", 40)
         extension = kwargs.get("extension", site_depth + 10)
         jackdown_time = jacksys.jacking_time(extension, site_depth)
-        yield vessel.task(
+        yield vessel.task_wrapper(
             "Jackdown",
             jackdown_time,
             constraints=vessel.transit_limits,
@@ -126,7 +126,7 @@ def position_onsite(vessel, **kwargs):
 
     position_time = kwargs.get("site_position_time", pt["site_position_time"])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Position Onsite", position_time, constraints=vessel.transit_limits
     )
 
@@ -181,7 +181,7 @@ def shuttle_items_to_queue(vessel, port, queue, distance, items, **kwargs):
             # Transit to site
             vessel.update_trip_data()
             vessel.at_port = False
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Transit", transit_time, constraints=vessel.transit_limits
             )
             yield stabilize(vessel, **kwargs)
@@ -220,7 +220,7 @@ def shuttle_items_to_queue(vessel, port, queue, distance, items, **kwargs):
             # Transit back to port
             vessel.at_site = False
             yield jackdown_if_required(vessel, **kwargs)
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Transit", transit_time, constraints=vessel.transit_limits
             )
             vessel.at_port = True
@@ -295,7 +295,7 @@ def get_list_of_items_from_port(vessel, port, items, **kwargs):
                         vessel.storage.put_item(item)
 
                         if time > 0:
-                            yield vessel.task(
+                            yield vessel.task_wrapper(
                                 action,
                                 time,
                                 constraints=vessel.transit_limits,

--- a/ORBIT/core/vessel.py
+++ b/ORBIT/core/vessel.py
@@ -5,11 +5,16 @@ __copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
 __maintainer__ = "Jake Nunemaker"
 __email__ = "jake.nunemaker@nrel.gov"
 
+from math import ceil
 from collections import Counter, namedtuple
 
 import numpy as np
 from marmot import Agent, le, process
-from marmot._exceptions import AgentNotRegistered
+from marmot._exceptions import (
+    StateExhausted,
+    WindowNotFound,
+    AgentNotRegistered,
+)
 
 from ORBIT.core.components import (
     Crane,
@@ -27,7 +32,7 @@ Trip = namedtuple("Trip", "cargo_mass deck_space items")
 class Vessel(Agent):
     """Base Vessel Class"""
 
-    def __init__(self, name, config):
+    def __init__(self, name, config, avail=1):
         """
         Creates an instance of Vessel.
 
@@ -40,6 +45,7 @@ class Vessel(Agent):
         super().__init__(name)
         self.config = config
         self.extract_vessel_dayrate()
+        self.avail = avail
 
     def submit_action_log(self, action, duration, **kwargs):
         """
@@ -75,6 +81,14 @@ class Vessel(Agent):
             }
 
             self.env._submit_log(payload, level="ACTION")
+
+    @process
+    def task_wrapper(
+        self, name, duration, constraints={}, suspendable=False, **kwargs
+    ):
+
+        duration /= self.avail
+        yield self.task(name, duration, constraints, suspendable, **kwargs)
 
     def extract_vessel_dayrate(self):
         """
@@ -288,7 +302,7 @@ class Vessel(Agent):
 
         action, time = item.release(**kwargs)
         if time > 0:
-            yield self.task(
+            yield self.task_wrapper(
                 action,
                 time,
                 constraints=self.transit_limits,
@@ -312,7 +326,7 @@ class Vessel(Agent):
         """
 
         time = self.transit_time(distance)
-        yield self.task(
+        yield self.task_wrapper(
             "Transit",
             time,
             constraints=self.transit_limits,

--- a/ORBIT/manager.py
+++ b/ORBIT/manager.py
@@ -470,11 +470,12 @@ class ProjectManager:
         _class = self.get_phase_class(name)
         _config = self.create_config_for_phase(name)
         processes = _config.pop("processes", {})
+        kwargs = {**kwargs, **processes}
 
         if _catch:
             try:
                 phase = _class(
-                    _config, weather=weather, phase_name=name, **processes
+                    _config, weather=weather, phase_name=name, **kwargs
                 )
                 phase.run()
 
@@ -483,9 +484,7 @@ class ProjectManager:
                 return None, None
 
         else:
-            phase = _class(
-                _config, weather=weather, phase_name=name, **processes
-            )
+            phase = _class(_config, weather=weather, phase_name=name, **kwargs)
             phase.run()
 
         self._phases[name] = phase
@@ -639,7 +638,7 @@ class ProjectManager:
                 self._output_logs.extend(logs)
 
         # Run remaining phases
-        self.run_dependent_phases(variable, zero)
+        self.run_dependent_phases(variable, zero, **kwargs)
 
     def run_dependent_phases(self, _phases, zero, **kwargs):
         """

--- a/ORBIT/phases/install/cable_install/array.py
+++ b/ORBIT/phases/install/cable_install/array.py
@@ -123,7 +123,7 @@ class ArrayCableInstallation(InstallPhase):
         vessel_specs = self.config.get("array_cable_install_vessel", None)
         name = vessel_specs.get("name", "Array Cable Installation Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()
@@ -141,7 +141,7 @@ class ArrayCableInstallation(InstallPhase):
             return
         name = vessel_specs.get("name", "Array Cable Burial Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()
@@ -159,7 +159,7 @@ class ArrayCableInstallation(InstallPhase):
             return
         name = vessel_specs.get("name", "Array Cable Trench Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()

--- a/ORBIT/phases/install/cable_install/common.py
+++ b/ORBIT/phases/install/cable_install/common.py
@@ -46,7 +46,7 @@ def load_cable_on_vessel(vessel, cable, constraints={}, **kwargs):
     load_time = kwargs.get(key, pt[key])
 
     vessel.cable_storage.load_cable(cable)
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Load Cable", load_time, constraints=constraints, **kwargs
     )
 
@@ -87,7 +87,7 @@ def prep_cable(vessel, **kwargs):
     key = "cable_prep_time"
     prep_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Prepare Cable", prep_time, constraints=vessel.transit_limits, **kwargs
     )
 
@@ -106,7 +106,7 @@ def lower_cable(vessel, **kwargs):
     key = "cable_lower_time"
     lower_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lower Cable",
         lower_time,
         constraints=vessel.operational_limits,
@@ -129,7 +129,7 @@ def pull_in_cable(vessel, **kwargs):
     key = "cable_pull_in_time"
     pull_in_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Pull In Cable",
         pull_in_time,
         constraints=vessel.operational_limits,
@@ -151,7 +151,7 @@ def terminate_cable(vessel, **kwargs):
     key = "cable_termination_time"
     termination_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Terminate Cable",
         termination_time,
         constraints=vessel.operational_limits,
@@ -180,7 +180,7 @@ def lay_bury_cable(vessel, distance, **kwargs):
     lay_bury_speed = kwargs.get(key, pt[key])
     lay_bury_time = distance / lay_bury_speed
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lay/Bury Cable",
         lay_bury_time,
         constraints=vessel.operational_limits,
@@ -210,7 +210,7 @@ def lay_cable(vessel, distance, **kwargs):
     lay_speed = kwargs.get(key, pt[key])
     lay_time = distance / lay_speed
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lay Cable",
         lay_time,
         constraints=vessel.operational_limits,
@@ -240,7 +240,7 @@ def bury_cable(vessel, distance, **kwargs):
     bury_speed = kwargs.get(key, pt[key])
     bury_time = distance / bury_speed
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Bury Cable",
         bury_time,
         constraints=vessel.operational_limits,
@@ -265,7 +265,7 @@ def splice_cable(vessel, **kwargs):
     key = "cable_splice_time"
     splice_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Splice Cable",
         splice_time,
         constraints=vessel.operational_limits,
@@ -290,7 +290,7 @@ def raise_cable(vessel, **kwargs):
     key = "cable_raise_time"
     raise_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Raise Cable",
         raise_time,
         constraints=vessel.operational_limits,
@@ -334,7 +334,7 @@ def tow_plow(vessel, distance, **kwargs):
     plow_speed = kwargs.get(key, pt[key])
     plow_time = distance / plow_speed
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Tow Plow", plow_time, constraints=vessel.operational_limits, **kwargs
     )
 
@@ -359,7 +359,7 @@ def pull_winch(vessel, distance, **kwargs):
     winch_speed = kwargs.get(key, pt[key])
     winch_time = distance / winch_speed
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Pull Winch",
         winch_time,
         constraints=vessel.operational_limits,
@@ -388,7 +388,7 @@ def dig_trench(vessel, distance, **kwargs):
     trench_dig_speed = kwargs.get(key, pt[key])
     trench_dig_time = distance / trench_dig_speed
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Dig Trench",
         trench_dig_time,
         constraints=vessel.operational_limits,

--- a/ORBIT/phases/install/cable_install/export.py
+++ b/ORBIT/phases/install/cable_install/export.py
@@ -208,7 +208,7 @@ class ExportCableInstallation(InstallPhase):
         vessel_specs = self.config.get("export_cable_install_vessel", None)
         name = vessel_specs.get("name", "Export Cable Installation Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()
@@ -225,7 +225,7 @@ class ExportCableInstallation(InstallPhase):
 
         name = vessel_specs.get("name", "Export Cable Burial Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()
@@ -241,7 +241,7 @@ class ExportCableInstallation(InstallPhase):
             return
         name = vessel_specs.get("name", "Export Cable Trench Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()

--- a/ORBIT/phases/install/install_phase.py
+++ b/ORBIT/phases/install/install_phase.py
@@ -13,7 +13,7 @@ import numpy as np
 import simpy
 import pandas as pd
 
-from ORBIT.core import Port, Environment
+from ORBIT.core import Port, Vessel, Environment
 from ORBIT.phases import BasePhase
 from ORBIT.core.defaults import common_costs
 
@@ -33,6 +33,7 @@ class InstallPhase(BasePhase):
 
         self.extract_phase_kwargs(**kwargs)
         self.initialize_environment(weather, **kwargs)
+        self.availability = kwargs.get("availability", None)
 
     def initialize_environment(self, weather, **kwargs):
         """
@@ -49,6 +50,20 @@ class InstallPhase(BasePhase):
 
         env_name = kwargs.get("env_name", "Environment")
         self.env = Environment(name=env_name, state=weather, **kwargs)
+
+    def initialize_vessel(self, name, specs):
+        """"""
+
+        avail = getattr(self, "availability")
+        if avail is None:
+            return Vessel(name, specs)
+
+        elif isinstance(avail, dict):
+            default = avail.get("default", 1)
+            return Vessel(name, specs, avail.get(name, default))
+
+        else:
+            return Vessel(name, specs, avail)
 
     @abstractmethod
     def setup_simulation(self):

--- a/ORBIT/phases/install/monopile_install/common.py
+++ b/ORBIT/phases/install/monopile_install/common.py
@@ -97,7 +97,7 @@ def upend_monopile(vessel, length, **kwargs):
     crane_rate = vessel.crane.crane_rate(**kwargs)
     upend_time = length / crane_rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Upend Monopile",
         upend_time,
         constraints=vessel.operational_limits,
@@ -128,7 +128,7 @@ def lower_monopile(vessel, **kwargs):
     height = (depth + 10) / rate  # Assumed 10m deck height added to site depth
     lower_time = height / rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lower Monopile",
         lower_time,
         constraints=vessel.operational_limits,
@@ -162,7 +162,7 @@ def drive_monopile(vessel, **kwargs):
 
     drive_time = mono_embed_len / mono_drive_rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Drive Monopile",
         drive_time,
         constraints=vessel.operational_limits,
@@ -185,7 +185,7 @@ def lower_transition_piece(vessel, **kwargs):
     vessel.task representing time to "Lower Transition Piece".
     """
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lower TP", 1, constraints=vessel.operational_limits, **kwargs
     )
 
@@ -210,7 +210,7 @@ def bolt_transition_piece(vessel, **kwargs):
     key = "tp_bolt_time"
     bolt_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Bolt TP", bolt_time, constraints=vessel.operational_limits, **kwargs
     )
 
@@ -233,7 +233,7 @@ def pump_transition_piece_grout(vessel, **kwargs):
     key = "grout_pump_time"
     pump_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Pump TP Grout",
         pump_time,
         constraints=vessel.operational_limits,
@@ -259,7 +259,7 @@ def cure_transition_piece_grout(vessel, **kwargs):
     key = "grout_cure_time"
     cure_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Cure TP Grout", cure_time, constraints=vessel.transit_limits, **kwargs
     )
 
@@ -285,7 +285,7 @@ def install_monopile(vessel, monopile, **kwargs):
     reequip_time = vessel.crane.reequip(**kwargs)
 
     yield lower_monopile(vessel, **kwargs)
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Crane Reequip",
         reequip_time,
         constraints=vessel.transit_limits,
@@ -329,7 +329,7 @@ def install_transition_piece(vessel, tp, **kwargs):
     connection = kwargs.get("tp_connection_type", "bolted")
     reequip_time = vessel.crane.reequip(**kwargs)
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Crane Reequip",
         reequip_time,
         constraints=vessel.transit_limits,

--- a/ORBIT/phases/install/monopile_install/standard.py
+++ b/ORBIT/phases/install/monopile_install/standard.py
@@ -168,7 +168,7 @@ class MonopileInstallation(InstallPhase):
         wtiv_specs = self.config.get("wtiv", None)
         name = wtiv_specs.get("name", "WTIV")
 
-        wtiv = Vessel(name, wtiv_specs)
+        wtiv = self.initialize_vessel(name, wtiv_specs)
         self.env.register(wtiv)
 
         wtiv.initialize()
@@ -189,7 +189,7 @@ class MonopileInstallation(InstallPhase):
             # TODO: Add in option for named feeders.
             name = "Feeder {}".format(n)
 
-            feeder = Vessel(name, feeder_specs)
+            feeder = self.initialize_vessel(name, feeder_specs)
             self.env.register(feeder)
 
             feeder.initialize()

--- a/ORBIT/phases/install/mooring_install/mooring.py
+++ b/ORBIT/phases/install/mooring_install/mooring.py
@@ -94,7 +94,7 @@ class MooringSystemInstallation(InstallPhase):
         vessel_specs = self.config.get("mooring_install_vessel", None)
         name = vessel_specs.get("name", "Mooring System Installation Vessel")
 
-        vessel = Vessel(name, vessel_specs)
+        vessel = self.initialize_vessel(name, vessel_specs)
         self.env.register(vessel)
 
         vessel.initialize()
@@ -204,7 +204,7 @@ def perform_mooring_site_survey(vessel, **kwargs):
     key = "mooring_site_survey_time"
     survey_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Perform Mooring Site Survey",
         survey_time,
         constraints=vessel.transit_limits,
@@ -247,7 +247,7 @@ def install_mooring_anchor(vessel, depth, _type, **kwargs):
         )
 
     install_time = fixed + 0.005 * depth
-    yield vessel.task(
+    yield vessel.task_wrapper(
         task, install_time, constraints=vessel.transit_limits, **kwargs
     )
 
@@ -271,7 +271,7 @@ def install_mooring_line(vessel, depth, **kwargs):
 
     install_time = 0.005 * depth
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Install Mooring Line",
         install_time,
         constraints=vessel.transit_limits,

--- a/ORBIT/phases/install/oss_install/common.py
+++ b/ORBIT/phases/install/oss_install/common.py
@@ -73,7 +73,7 @@ def lift_topside(vessel, **kwargs):
     crane_rate = vessel.crane.crane_rate(**kwargs)
     lift_time = lift_height / crane_rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lift Topside", lift_time, constraints=vessel.operational_limits
     )
 
@@ -100,7 +100,7 @@ def attach_topside(vessel, **kwargs):
     key = "topside_attach_time"
     attach_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Attach Topside", attach_time, constraints=vessel.operational_limits
     )
 
@@ -126,7 +126,7 @@ def install_topside(vessel, topside, **kwargs):
     connection = kwargs.get("topside_connection_type", "bolted")
     reequip_time = vessel.crane.reequip(**kwargs)
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Crane Reequip",
         reequip_time,
         constraints=vessel.transit_limits,

--- a/ORBIT/phases/install/oss_install/standard.py
+++ b/ORBIT/phases/install/oss_install/standard.py
@@ -144,7 +144,7 @@ class OffshoreSubstationInstallation(InstallPhase):
         oss_vessel_specs = self.config.get("oss_install_vessel", None)
         name = oss_vessel_specs.get("name", "Heavy Lift Vessel")
 
-        oss_vessel = Vessel(name, oss_vessel_specs)
+        oss_vessel = self.initialize_vessel(name, oss_vessel_specs)
         self.env.register(oss_vessel)
 
         oss_vessel.initialize()
@@ -165,7 +165,7 @@ class OffshoreSubstationInstallation(InstallPhase):
             # TODO: Add in option for named feeders.
             name = "Feeder {}".format(n)
 
-            feeder = Vessel(name, feeder_specs)
+            feeder = self.initialize_vessel(name, feeder_specs)
             self.env.register(feeder)
 
             feeder.initialize()

--- a/ORBIT/phases/install/quayside_assembly_tow/gravity_base.py
+++ b/ORBIT/phases/install/quayside_assembly_tow/gravity_base.py
@@ -216,7 +216,7 @@ class GravityBasedInstallation(InstallPhase):
         """
 
         specs = self.config["support_vessel"]
-        vessel = Vessel("Multi-Purpose Support Vessel", specs)
+        vessel = self.initialize_vessel("Multi-Purpose Support Vessel", specs)
 
         self.env.register(vessel)
         vessel.initialize(mobilize=False)
@@ -363,19 +363,19 @@ def install_gravity_base_foundations(
                 vessel.mobilize()
                 yield vessel.transit(distance)
 
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Position Substructure",
                 5,
                 constraints={"windspeed": le(15), "waveheight": le(2)},
             )
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "ROV Survey",
                 1,
                 constraints={"windspeed": le(25), "waveheight": le(3)},
             )
 
             # TODO: Model for ballast pump time
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Pump Ballast",
                 12,
                 # suspendable=True,
@@ -383,7 +383,7 @@ def install_gravity_base_foundations(
             )
 
             # TODO: Model for GBF grout time
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Grout GBF",
                 6,
                 suspendable=True,

--- a/ORBIT/phases/install/quayside_assembly_tow/moored.py
+++ b/ORBIT/phases/install/quayside_assembly_tow/moored.py
@@ -215,7 +215,7 @@ class MooredSubInstallation(InstallPhase):
         """
 
         specs = self.config["support_vessel"]
-        vessel = Vessel("Multi-Purpose Support Vessel", specs)
+        vessel = self.initialize_vessel("Multi-Purpose Support Vessel", specs)
 
         self.env.register(vessel)
         vessel.initialize(mobilize=False)
@@ -372,23 +372,23 @@ def install_moored_substructures(
                 vessel.mobilize()
                 yield vessel.transit(distance)
 
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Position Substructure",
                 2,
                 constraints={"windspeed": le(15), "waveheight": le(2.5)},
             )
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Ballast to Operational Draft",
                 6,
                 constraints={"windspeed": le(15), "waveheight": le(2.5)},
             )
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Connect Mooring Lines",
                 22,
                 suspendable=True,
                 constraints={"windspeed": le(15), "waveheight": le(2.5)},
             )
-            yield vessel.task(
+            yield vessel.task_wrapper(
                 "Check Mooring Lines",
                 12,
                 suspendable=True,

--- a/ORBIT/phases/install/scour_protection_install/standard.py
+++ b/ORBIT/phases/install/scour_protection_install/standard.py
@@ -127,7 +127,7 @@ class ScourProtectionInstallation(InstallPhase):
         spi_specs = self.config["spi_vessel"]
         name = spi_specs.get("name", "SPI Vessel")
 
-        spi_vessel = Vessel(name, spi_specs)
+        spi_vessel = self.initialize_vessel(name, spi_specs)
         self.env.register(spi_vessel)
 
         spi_vessel.initialize()
@@ -246,7 +246,7 @@ def load_material(vessel, mass, **kwargs):
     load_time = kwargs.get(key, pt[key])
 
     vessel.rock_storage.put(mass)
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Load SP Material",
         load_time,
         constraints=vessel.transit_limits,
@@ -276,7 +276,7 @@ def drop_material(vessel, mass, **kwargs):
     drop_time = kwargs.get(key, pt[key])
 
     _ = vessel.rock_storage.get(mass)
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Drop SP Material",
         drop_time,
         constraints=vessel.transit_limits,

--- a/ORBIT/phases/install/turbine_install/common.py
+++ b/ORBIT/phases/install/turbine_install/common.py
@@ -125,7 +125,7 @@ def lift_nacelle(vessel, **kwargs):
     crane_rate = vessel.crane.crane_rate(**kwargs)
     lift_time = hub_height / crane_rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lift Nacelle",
         lift_time,
         constraints=vessel.operational_limits,
@@ -154,7 +154,7 @@ def attach_nacelle(vessel, **kwargs):
     key = "nacelle_attach_time"
     attach_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Attach Nacelle",
         attach_time,
         constraints=vessel.operational_limits,
@@ -183,7 +183,7 @@ def lift_turbine_blade(vessel, **kwargs):
     crane_rate = vessel.crane.crane_rate(**kwargs)
     lift_time = hub_height / crane_rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lift Blade",
         lift_time,
         constraints=vessel.operational_limits,
@@ -212,7 +212,7 @@ def attach_turbine_blade(vessel, **kwargs):
     key = "blade_attach_time"
     attach_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Attach Blade",
         attach_time,
         constraints=vessel.operational_limits,
@@ -240,7 +240,7 @@ def lift_tower_section(vessel, height, **kwargs):
     crane_rate = vessel.crane.crane_rate(**kwargs)
     lift_time = height / crane_rate
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Lift Tower Section",
         lift_time,
         constraints=vessel.operational_limits,
@@ -269,7 +269,7 @@ def attach_tower_section(vessel, **kwargs):
     key = "tower_section_attach_time"
     attach_time = kwargs.get(key, pt[key])
 
-    yield vessel.task(
+    yield vessel.task_wrapper(
         "Attach Tower Section",
         attach_time,
         constraints=vessel.operational_limits,

--- a/ORBIT/phases/install/turbine_install/standard.py
+++ b/ORBIT/phases/install/turbine_install/standard.py
@@ -173,7 +173,7 @@ class TurbineInstallation(InstallPhase):
         wtiv_specs = self.config.get("wtiv", None)
         name = wtiv_specs.get("name", "WTIV")
 
-        wtiv = Vessel(name, wtiv_specs)
+        wtiv = self.initialize_vessel(name, wtiv_specs)
         self.env.register(wtiv)
 
         wtiv.initialize()
@@ -194,7 +194,7 @@ class TurbineInstallation(InstallPhase):
             # TODO: Add in option for named feeders.
             name = "Feeder {}".format(n)
 
-            feeder = Vessel(name, feeder_specs)
+            feeder = self.initialize_vessel(name, feeder_specs)
             self.env.register(feeder)
 
             feeder.initialize()
@@ -343,13 +343,13 @@ def solo_install_turbines(
                 )
 
                 # Install nacelle
-                yield vessel.task(
+                yield vessel.task_wrapper(
                     "Reequip", reequip_time, constraints=vessel.transit_limits
                 )
                 yield install_nacelle(vessel, nacelle, **kwargs)
 
                 # Install turbine blades
-                yield vessel.task(
+                yield vessel.task_wrapper(
                     "Reequip", reequip_time, constraints=vessel.transit_limits
                 )
                 for _ in range(num_blades):
@@ -431,13 +431,13 @@ def install_turbine_components_from_queue(
                 )
 
                 # Install nacelle
-                yield wtiv.task(
+                yield wtiv.task_wrapper(
                     "Reequip", reequip_time, constraints=wtiv.transit_limits
                 )
                 yield install_nacelle(wtiv, nacelle, **kwargs)
 
                 # Install turbine blades
-                yield wtiv.task(
+                yield wtiv.task_wrapper(
                     "Reequip", reequip_time, constraints=wtiv.transit_limits
                 )
 


### PR DESCRIPTION
This is an alternative approach to handling weather downtime when we don't have or want to use a time series. Instead of calculating the downtime dynamically against the weather profile, this can be used to simply scale the process times (and associated cost) based on an assumed availability. It works by passing in an availability parameter to the `ProjectManager.run()` method like so:

![Screen Shot 2021-03-31 at 12 44 15 PM](https://user-images.githubusercontent.com/42254629/113194858-d24f0400-921e-11eb-84c4-f46439b59bf4.png)

Note that you pass in a single value (top example) or a dict (bottom example). A single value will scale all vessels by `process_time / avail`. With the dict you can specific availability per vessel and all others get the default value (which defaults to 1).

I'm curious what you guys think about this. It's been something I've been thinking about for awhile. I think it'll be useful for quickly getting something set up, working on projects that aren't tied to specific sites and the WISDEM API.