### PR TITLE
Fixed monopile thickness bug. Had to double value in mass assertion

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/ORBIT/phases/design/monopile_design.py
+++ b/ORBIT/phases/design/monopile_design.py
@@ -230,7 +230,7 @@ class MonopileDesign(DesignPhase):
             "diameter": D_tp,
             "mass": m_tp,
             "length": L_tp,
-            "deck_space": D_tp ** 2,
+            "deck_space": D_tp**2,
             "unit_cost": m_tp * self.tp_steel_cost,
         }
 
@@ -355,7 +355,7 @@ class MonopileDesign(DesignPhase):
         """
 
         density = kwargs.get("monopile_density", 7860)  # kg/m3
-        volume = (pi / 4) * (Dp ** 2 - (Dp - tp) ** 2) * Lt
+        volume = (pi / 4) * (Dp**2 - (Dp - 2 * tp) ** 2) * Lt
         mass = density * volume / 907.185
 
         return mass
@@ -482,7 +482,8 @@ class MonopileDesign(DesignPhase):
             Rated windspeed of turbine (m/s).
         load_factor : float
             Added safety factor on the extreme wind moment.
-            Default: 3.375 (2.5x DNV standard as this model does not design for buckling or fatigue)
+            Default: 3.375 (2.5x DNV standard as this model
+             does not design for buckling or fatigue)
 
         Returns
         -------
@@ -559,16 +560,15 @@ class MonopileDesign(DesignPhase):
             Coefficient of thrust.
         """
 
-        ct = min(
-            [3.5 * (2 * rated_windspeed + 3.5) / (rated_windspeed ** 2), 1]
-        )
+        ct = min([3.5 * (2 * rated_windspeed + 3.5) / (rated_windspeed**2), 1])
 
         return ct
 
     @staticmethod
     def calculate_50year_extreme_ws(mean_windspeed, **kwargs):
         """
-        Calculates the 50 year extreme wind speed using methodology from DNV-GL.
+        Calculates the 50 year extreme wind speed using methodology
+        from DNV-GL.
         Source: Arany & Bhattacharya (2016)
         - Equation 27
 

--- a/tests/phases/design/test_monopile_design.py
+++ b/tests/phases/design/test_monopile_design.py
@@ -54,7 +54,7 @@ def test_paramater_sweep(depth, mean_ws, turbine):
     assert 4 < m._outputs["monopile"]["diameter"] < 13
 
     # Check valid monopile mass
-    assert 200 < m._outputs["monopile"]["mass"] < 2500
+    assert 200 < m._outputs["monopile"]["mass"] < 5000
 
     # Check valid transition piece diameter
     assert 4 < m._outputs["transition_piece"]["diameter"] < 14


### PR DESCRIPTION
Addresses #155. Fixed the bug in the hollow cylinder volume calculation in  `monopile_design.py`. 

The new volume and mass calculation broke the `test_monopile_design.py`, so I had to adjust the mass assert to be 5000 tons (originally 2500). 