### PR TITLE
Reorganizing common costs in design modules

### DIFF
--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -42,6 +42,19 @@ substation_design:
   oss_substructure_cost_rate: 3000              # USD/t
   oss_pile_cost_rate: 0                         # USD/t
 
+# Onshore substation component cost rates
+onshore_substation_design:
+  shunt_unit_cost: 1.3e4                        # USD/cable
+  switchgear_cost: 9.33e6                       # USD/cable
+  compensation_rate: 31.3e6                     # USD/cable
+  onshore_converter_cost:                       # USD
+    HVAC: 0
+    HVDC-monopole: 157e6
+    HVDC-bipole: 350e6
+  onshore_construction_rate:                    # USD
+    HVAC: 5e6
+    HVDC-monopole: 87.3e6
+    HVDC-bipole: 100e6
 
 # Semisubmersible component cost rates
 semisubmersible_design:

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -1,6 +1,7 @@
 # Material costs
-monopile_steel_cost: 3000                     # USD/t
-tp_steel_cost: 3000                           # USD/t
+monopile_design:
+  monopile_steel_cost: 3000                     # USD/t
+  tp_steel_cost: 3000                           # USD/t
 
 # Port properties
 port_cost_per_month: 2e6                      # USD/month
@@ -29,6 +30,6 @@ offshore_design:
 # Semisubmersible component cost rates
 semisubmersible_design:
   stiffened_column_CR: 3120                     # USD/t
-  truss_CR: 6250                              # USD/t
+  truss_CR: 6250                                # USD/t
   heave_plate_CR: 6250                          # USD/t
   secondary_steel_CR: 7250                      # USD/t

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -6,6 +6,10 @@ monopile_design:
 # Port properties
 port_cost_per_month: 2e6                      # USD/month
 
+# Export system component cost rates
+export_system_design:
+  cable_crossings:
+    crossing_unit_cost: 500000
 # Spar component cost rates
 spar_design:
   stiffened_column_CR: 3120                     # USD/t
@@ -14,18 +18,30 @@ spar_design:
   secondary_steel_CR: 7250                      # USD/t
 
 # Offshore substation component cost rates
-offshore_design:
+substation_design:
   mpt_cost_rate: 12500                          # USD/MW
   topside_fab_cost_rate: 14500                  # USD/t
-  topside_design_cost: 4.5e6                    # USD
+  topside_design_cost:                          # USD
+    #oldHVAC: 4.5e6
+    HVAC: 107.3e6
+    HVDC-monopole: 294e6
+    HVDC-bipole: 476e6
   shunt_cost_rate: 35000                        # USD/MW
-  switchgear_cost: 4e6                          # USD/num_mpt
+  mpt_unit_cost: 2.87e6                         # USD/mpt
+  shunt_unit_cost: 1e4                          # USD/cable
+  switchgear_cost: 4e6                          # USD/cable
+  dc_breaker_cost: 10.5e6                       # USD/cable
   backup_gen_cost: 1e6                          # USD
   workspace_cost: 2e6                           # USD
   other_ancillary_cost: 3e6                     # USD
   topside_assembly_factor: 0.075                # %
+  converter_cost:                               # USD
+    HVAC: 0
+    HVDC-monopole: 127e6
+    HVDC-bipole: 296e6
   oss_substructure_cost_rate: 3000              # USD/t
   oss_pile_cost_rate: 0                         # USD/t
+
 
 # Semisubmersible component cost rates
 semisubmersible_design:

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -62,3 +62,7 @@ semisubmersible_design:
   truss_CR: 6250                                # USD/t
   heave_plate_CR: 6250                          # USD/t
   secondary_steel_CR: 7250                      # USD/t
+
+# Mooring system component cost rates
+mooring_system_design:                          # USD/m
+  mooring_line_cost_rate: [399.0, 721.0, 1088.0]

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -4,3 +4,30 @@ tp_steel_cost: 3000                           # USD/t
 
 # Port properties
 port_cost_per_month: 2e6                      # USD/month
+
+# Spar component cost rates
+spar_design:
+  stiffened_column_CR: 3120                     # USD/t
+  tapered_column_CR: 4220                       # USD/t
+  ballast_material_CR: 100                      # USD/t
+  secondary_steel_CR: 7250                      # USD/t
+
+# Offshore substation component cost rates
+offshore_design:
+  mpt_cost_rate: 12500                          # USD/MW
+  topside_fab_cost_rate: 14500                  # USD/t
+  topside_design_cost: 4.5e6                    # USD
+  shunt_cost_rate: 35000                        # USD/MW
+  switchgear_cost: 4e6                          # USD/num_mpt
+  backup_gen_cost: 1e6                          # USD
+  workspace_cost: 2e6                           # USD
+  other_ancillary_cost: 3e6                     # USD
+  topside_assembly_factor: 0.075                # %
+  oss_substructure_cost_rate: 3000              # USD/t
+  oss_pile_cost_rate: 0                         # USD/t
+
+# Semisubmersible component cost rates
+#stiffened_column_CR: 3120                     # USD/t
+truss_cost: 6250                              # USD/t
+heave_plate_CR: 6250                          # USD/t
+#secondary_steel_CR: 7250                      # USD/t

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -10,6 +10,7 @@ port_cost_per_month: 2e6                      # USD/month
 export_system_design:
   cable_crossings:
     crossing_unit_cost: 500000
+
 # Spar component cost rates
 spar_design:
   stiffened_column_CR: 3120                     # USD/t
@@ -28,7 +29,7 @@ substation_design:
     HVDC-bipole: 476e6
   shunt_cost_rate: 35000                        # USD/MW
   mpt_unit_cost: 2.87e6                         # USD/mpt
-  shunt_unit_cost: 1e4                          # USD/cable
+  shunt_unit_cost: 10000                        # USD/cable
   switchgear_cost: 4e6                          # USD/cable
   dc_breaker_cost: 10.5e6                       # USD/cable
   backup_gen_cost: 1e6                          # USD
@@ -44,7 +45,7 @@ substation_design:
 
 # Onshore substation component cost rates
 onshore_substation_design:
-  shunt_unit_cost: 1.3e4                        # USD/cable
+  shunt_unit_cost: 13000                        # USD/cable
   switchgear_cost: 9.33e6                       # USD/cable
   compensation_rate: 31.3e6                     # USD/cable
   onshore_converter_cost:                       # USD

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -45,13 +45,16 @@ substation_design:
 
 # Onshore substation component cost rates
 onshore_substation_design:
-  shunt_unit_cost: 13000                        # USD/cable
-  switchgear_cost: 9.33e6                       # USD/cable
-  compensation_rate: 31.3e6                     # USD/cable
   onshore_converter_cost:                       # USD
     HVAC: 0
     HVDC-monopole: 157e6
     HVDC-bipole: 350e6
+  shunt_unit_cost: 13000                        # USD/cable
+  switchgear_cost: 9.33e6                       # USD/cable
+  compensation_rate:                            # USD/cable
+    HVAC: 31.3e6
+    HVDC-monopole: 0
+    HVDC-bipole: 0
   onshore_construction_rate:                    # USD
     HVAC: 5e6
     HVDC-monopole: 87.3e6

--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -27,7 +27,8 @@ offshore_design:
   oss_pile_cost_rate: 0                         # USD/t
 
 # Semisubmersible component cost rates
-#stiffened_column_CR: 3120                     # USD/t
-truss_cost: 6250                              # USD/t
-heave_plate_CR: 6250                          # USD/t
-#secondary_steel_CR: 7250                      # USD/t
+semisubmersible_design:
+  stiffened_column_CR: 3120                     # USD/t
+  truss_CR: 6250                              # USD/t
+  heave_plate_CR: 6250                          # USD/t
+  secondary_steel_CR: 7250                      # USD/t

--- a/ORBIT/phases/base.py
+++ b/ORBIT/phases/base.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from benedict import benedict
 
 from ORBIT.core.library import initialize_library, extract_library_data
+from ORBIT.core.defaults import common_costs
 from ORBIT.core.exceptions import MissingInputs
 
 
@@ -116,6 +117,37 @@ class BasePhase(ABC):
 
         else:
             return benedict(config)
+
+    def set_default_cost(self, design_name, key, subkey=None):
+        """Return the cost value for a key in a design
+        dictionary read from common_cost.yaml.
+        """
+
+        if (design_dict := common_costs.get(design_name, None)) is None:
+            raise KeyError(f"No {design_name} in common_cost.yaml.")
+
+        # expected = deepcopy(getattr(self, "expected_config", None))
+        # if expected is None:
+        #    raise AttributeError(f"'expected_config' not set for '{self}'.")
+        # design_name = deepcopy(getattr(self,
+        # f"expected_config.{design_name}"))
+
+        if (cost_value := design_dict.get(key, None)) is None:
+            raise KeyError(
+                f"{key} not found in [{design_name}] common_costs.yaml."
+            )
+
+        if isinstance(cost_value, dict):
+            if (sub_cost_value := cost_value.get(subkey, None)) is None:
+                raise KeyError(
+                    f"{subkey} not found in [{design_name}][{cost_value}]"
+                    " common_costs."
+                )
+
+            return sub_cost_value
+
+        else:
+            return cost_value
 
     @abstractmethod
     def run(self):

--- a/ORBIT/phases/base.py
+++ b/ORBIT/phases/base.py
@@ -12,7 +12,6 @@ from copy import deepcopy
 from benedict import benedict
 
 from ORBIT.core.library import initialize_library, extract_library_data
-from ORBIT.core.defaults import common_costs
 from ORBIT.core.exceptions import MissingInputs
 
 
@@ -117,37 +116,6 @@ class BasePhase(ABC):
 
         else:
             return benedict(config)
-
-    def set_default_cost(self, design_name, key, subkey=None):
-        """Return the cost value for a key in a design
-        dictionary read from common_cost.yaml.
-        """
-
-        if (design_dict := common_costs.get(design_name, None)) is None:
-            raise KeyError(f"No {design_name} in common_cost.yaml.")
-
-        # expected = deepcopy(getattr(self, "expected_config", None))
-        # if expected is None:
-        #    raise AttributeError(f"'expected_config' not set for '{self}'.")
-        # design_name = deepcopy(getattr(self,
-        # f"expected_config.{design_name}"))
-
-        if (cost_value := design_dict.get(key, None)) is None:
-            raise KeyError(
-                f"{key} not found in [{design_name}] common_costs.yaml."
-            )
-
-        if isinstance(cost_value, dict):
-            if (sub_cost_value := cost_value.get(subkey, None)) is None:
-                raise KeyError(
-                    f"{subkey} not found in [{design_name}][{cost_value}]"
-                    " common_costs."
-                )
-
-            return sub_cost_value
-
-        else:
-            return cost_value
 
     @abstractmethod
     def run(self):

--- a/ORBIT/phases/design/design_phase.py
+++ b/ORBIT/phases/design/design_phase.py
@@ -47,7 +47,7 @@ class DesignPhase(BasePhase):
         if isinstance(cost_value, dict):
             if subkey is None:
                 raise ValueError(
-                    f"{key} is a dictionary and requires a" " 'subkey' input."
+                    f"{key} is a dictionary and requires a 'subkey' input."
                 )
 
             if (sub_cost_value := cost_value.get(subkey, None)) is None:

--- a/ORBIT/phases/design/design_phase.py
+++ b/ORBIT/phases/design/design_phase.py
@@ -9,6 +9,7 @@ __email__ = "jake.nunemaker@nrel.gov"
 from abc import abstractmethod
 
 from ORBIT.phases import BasePhase
+from ORBIT.core.defaults import common_costs
 
 
 class DesignPhase(BasePhase):
@@ -31,3 +32,32 @@ class DesignPhase(BasePhase):
         """
 
         return {}
+
+    def get_default_cost(self, design_name, key, subkey=None):
+        """Return the cost value for a key in a design
+        dictionary read from common_cost.yaml.
+        """
+
+        if (design_dict := common_costs.get(design_name, None)) is None:
+            raise KeyError(f"No {design_name} in common_cost.yaml.")
+
+        # expected = deepcopy(getattr(self, "expected_config", None))
+        # if expected is None:
+        #    raise AttributeError(f"'expected_config' not set for '{self}'.")
+        # design_name = deepcopy(getattr(self,
+        # f"expected_config.{design_name}"))
+
+        if (cost_value := design_dict.get(key, None)) is None:
+            raise KeyError(f"{key} not found in [{design_name}] common_costs.")
+
+        if isinstance(cost_value, dict):
+            if (sub_cost_value := cost_value.get(subkey, None)) is None:
+                raise KeyError(
+                    f"{subkey} not found in [{design_name}][{cost_value}]"
+                    " common_costs."
+                )
+
+            return sub_cost_value
+
+        else:
+            return cost_value

--- a/ORBIT/phases/design/design_phase.py
+++ b/ORBIT/phases/design/design_phase.py
@@ -41,16 +41,15 @@ class DesignPhase(BasePhase):
         if (design_dict := common_costs.get(design_name, None)) is None:
             raise KeyError(f"No {design_name} in common_cost.yaml.")
 
-        # expected = deepcopy(getattr(self, "expected_config", None))
-        # if expected is None:
-        #    raise AttributeError(f"'expected_config' not set for '{self}'.")
-        # design_name = deepcopy(getattr(self,
-        # f"expected_config.{design_name}"))
-
         if (cost_value := design_dict.get(key, None)) is None:
             raise KeyError(f"{key} not found in [{design_name}] common_costs.")
 
         if isinstance(cost_value, dict):
+            if subkey is None:
+                raise ValueError(
+                    f"{key} is a dictionary and requires a" " 'subkey' input."
+                )
+
             if (sub_cost_value := cost_value.get(subkey, None)) is None:
                 raise KeyError(
                     f"{subkey} not found in [{design_name}][{cost_value}]"

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -742,7 +742,7 @@ class ElectricalDesign(CableSystem):
             raise KeyError(f"{_key} not found in common_costs.")
 
         if isinstance(_converter_cost, dict):
-            _converter_cost = _converter_cost[self.cable_type.cable]
+            _converter_cost = _converter_cost[self.cable.cable_type]
 
         _key = "onshore_construction_rate"
         if (
@@ -753,7 +753,7 @@ class ElectricalDesign(CableSystem):
             raise KeyError(f"{_key} not found in common_costs.")
 
         if isinstance(_construction_rate, dict):
-            _construction_rate = _construction_rate[self.cable_type.cable]
+            _construction_rate = _construction_rate[self.cable.cable_type]
 
         if self.cable.cable_type == "HVDC-monopole":
             self.onshore_converter_cost = (

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -471,11 +471,11 @@ class ElectricalDesign(CableSystem):
             _key, self.get_default_cost("substation_design", _key)
         )
 
-        num_switchgear = (
+        self.num_switchgear = (
             0 if "HVDC" in self.cable.cable_type else self.num_cables
         )
 
-        self.switchgear_cost = num_switchgear * switchgear_cost
+        self.switchgear_cost = self.num_switchgear * switchgear_cost
 
     def calc_dc_breaker_cost(self):
         """Computes HVDC circuit breaker cost. Breaker cost is 0 for HVAC.
@@ -679,7 +679,7 @@ class ElectricalDesign(CableSystem):
             _key, self.get_default_cost("onshore_substation_design", _key)
         )
 
-        self.onshore_switchgear_cost = self.num_cables * _switchgear_cost
+        self.onshore_switchgear_cost = self.num_switchgear * _switchgear_cost
 
         _key = "onshore_construction_rate"
         _construction_rate = _design.get(
@@ -711,6 +711,13 @@ class ElectricalDesign(CableSystem):
         self.onshore_compensation_cost = (
             self.num_cables * _compensation_rate
             + self.onshore_shunt_reactor_cost
+        )
+        print(
+            f"converter: {self.onshore_converter_cost}"
+            f" switchgear: {self.onshore_switchgear_cost}"
+            f"construction:{self.onshore_construction}"
+            f" compensation: {self.onshore_compensation_cost}"
+            f" mpt_cost:{self.mpt_cost}"
         )
 
         self.onshore_cost = (

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -9,7 +9,21 @@ from warnings import warn
 
 import numpy as np
 
+from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design._cables import CableSystem
+
+"""
+[1] Maness et al. 2017, NREL Offshore Balance-of-System Model.
+https://www.nrel.gov/docs/fy17osti/66874.pdf
+"""
+
+if (
+    export_design_cost := common_costs.get("export_system_design", None)
+) is None:
+    raise KeyError("No export system in common costs.")
+
+if (oss_design_cost := common_costs.get("substation_design", None)) is None:
+    raise KeyError("No substation design in common costs.")
 
 
 class ElectricalDesign(CableSystem):
@@ -93,6 +107,7 @@ class ElectricalDesign(CableSystem):
                 "cable_type": "str",
             },
         },
+        "offshore_substation": "dict, (optional)",
     }
 
     def __init__(self, config, **kwargs):
@@ -106,10 +121,13 @@ class ElectricalDesign(CableSystem):
 
         for name in self.expected_config["site"]:
             setattr(self, "".join(("_", name)), config["site"][name])
+
         self._depth = config["site"]["depth"]
         self._distance_to_landfall = config["site"]["distance_to_landfall"]
         self._plant_capacity = self.config["plant"]["capacity"]
         self._get_touchdown_distance()
+
+        self._design = self.config["export_system_design"]
 
         _landfall = self.config.get("landfall", {})
         if _landfall:
@@ -121,23 +139,16 @@ class ElectricalDesign(CableSystem):
             )
 
         else:
-            _landfall = self.config["export_system_design"].get("landfall", {})
+            _landfall = self._design.get("landfall", {})
 
         self._distance_to_interconnection = _landfall.get(
             "interconnection_distance", 3
         )
 
-        self.export_system_design = self.config["export_system_design"]
-        self.offshore_substation_design = self.config.get(
-            "substation_design", {}
-        )
+        self._oss_design = self.config.get("substation_design", {})
 
-        self.substructure_type = self.offshore_substation_design.get(
+        self.substructure_type = self._oss_design.get(
             "oss_substructure_type", "Monopile"
-        )
-
-        self.onshore_substation_design = self.config.get(
-            "onshore_substation_design", {}
         )
 
         self._outputs = {}
@@ -187,6 +198,16 @@ class ElectricalDesign(CableSystem):
         self.calc_dc_breaker_cost()
         self.calc_onshore_cost()
 
+        self._outputs["offshore_substation"] = {
+            "substation_mpt_cost": self.mpt_cost,
+            "substation_shunt_cost": self.shunt_reactor_cost,
+            "substation_switchgear_cost": self.switchgear_cost,
+            "substation_converter_cost": self.converter_cost,
+            "substation_breaker_cost": self.dc_breaker_cost,
+            "substation_ancillary_cost": self.ancillary_system_costs,
+            "substation_land_assembly_cost": self.land_assembly_cost,
+        }
+
         self._outputs["offshore_substation_substructure"] = {
             "type": self.substructure_type,
             "deck_space": self.substructure_deck_space,
@@ -221,6 +242,13 @@ class ElectricalDesign(CableSystem):
             "substation_substructure_mass": self.substructure_mass,
             "substation_substructure_cost": self.substructure_cost,
             "total_substation_cost": self.total_substation_cost,
+            "substation_mpt_cost": self.mpt_cost,
+            "substation_shunt_cost": self.shunt_reactor_cost,
+            "substation_switchgear_cost": self.switchgear_cost,
+            "substation_converter_cost": self.converter_cost,
+            "substation_breaker_cost": self.dc_breaker_cost,
+            "substation_ancillary_cost": self.ancillary_system_costs,
+            "substation_land_assembly_cost": self.land_assembly_cost,
             "onshore_shunt_cost": self.onshore_shunt_reactor_cost,
             "onshore_converter_cost": self.onshore_converter_cost,
             "onshore_switchgear_cost": self.onshore_switchgear_cost,
@@ -253,8 +281,6 @@ class ElectricalDesign(CableSystem):
         ----------
         num_redundant : int
         """
-
-        _num_redundant = self._design.get("num_redundant", 0)
 
         num_required = np.ceil(self._plant_capacity / self.cable.cable_power)
         num_redundant = self._design.get("num_redundant", 0)
@@ -320,12 +346,19 @@ class ElectricalDesign(CableSystem):
 
     def calc_crossing_cost(self):
         """Compute cable crossing costs."""
-        self._crossing_design = self.config["export_system_design"].get(
-            "cable_crossings", {}
+        _crossing_design = self._design.get("cable_crossings", {})
+
+        _key = "crossing_unit_cost"
+        if (
+            crossing_cost := _crossing_design.get(
+                _key, export_design_cost["cable_crossings"].get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        self.crossing_cost = crossing_cost * _crossing_design.get(
+            "crossing_number", 0
         )
-        self.crossing_cost = self._crossing_design.get(
-            "crossing_unit_cost", 500000
-        ) * self._crossing_design.get("crossing_number", 0)
 
         """SUBSTATION"""
 
@@ -347,16 +380,16 @@ class ElectricalDesign(CableSystem):
         """
 
         # HVAC substation capacity
-        _substation_capacity = self.offshore_substation_design.get(
+        _substation_capacity = self._oss_design.get(
             "substation_capacity", 1200
         )  # MW
 
         if "HVDC" in self.cable.cable_type:
-            self.num_substations = self.offshore_substation_design.get(
+            self.num_substations = self._oss_design.get(
                 "num_substations", int(self.num_cables / 2)
             )
         else:
-            self.num_substations = self.offshore_substation_design.get(
+            self.num_substations = self._oss_design.get(
                 "num_substations",
                 int(np.ceil(self._plant_capacity / _substation_capacity)),
             )
@@ -383,15 +416,19 @@ class ElectricalDesign(CableSystem):
         mpt_unit_cost : int | float
         """
 
-        _mpt_cost = self._design.get("mpt_unit_cost", 2.87e6)
+        _key = "mpt_unit_cost"
+        if (
+            _mpt_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         self.num_mpt = self.num_cables
 
-        if "HVDC" in self.cable.cable_type:
-            self.mpt_cost = 0
-
-        else:
-            self.mpt_cost = self.num_mpt * _mpt_cost
+        self.mpt_cost = (
+            0 if "HVDC" in self.cable.cable_type else self.num_mpt * _mpt_cost
+        )
 
         self.mpt_rating = (
             round((self._plant_capacity * 1.15 / self.num_mpt) / 10.0) * 10.0
@@ -406,13 +443,21 @@ class ElectricalDesign(CableSystem):
         """
 
         touchdown = self.config["site"]["distance_to_landfall"]
-        shunt_unit_cost = self._design.get("shunt_unit_cost", 1e4)
+
+        _key = "shunt_unit_cost"
+        if (
+            shunt_unit_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         if "HVDC" in self.cable.cable_type:
             self.compensation = 0
         else:
             for cable in self.cables.values():
                 self.compensation = touchdown * cable.compensation_factor  # MW
+
         self.shunt_reactor_cost = (
             self.compensation * shunt_unit_cost * self.num_cables
         )
@@ -425,7 +470,13 @@ class ElectricalDesign(CableSystem):
         switchgear_cost : int | float
         """
 
-        switchgear_cost = self._design.get("switchgear_cost", 4e6)
+        _key = "switchgear_cost"
+        if (
+            switchgear_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         num_switchgear = (
             0 if "HVDC" in self.cable.cable_type else self.num_cables
@@ -441,7 +492,13 @@ class ElectricalDesign(CableSystem):
         dc_breaker_cost : int | float
         """
 
-        dc_breaker_cost = self._design.get("dc_breaker_cost", 10.5e6)
+        _key = "dc_breaker_cost"
+        if (
+            dc_breaker_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         num_dc_breakers = (
             self.num_cables if "HVDC" in self.cable.cable_type else 0
@@ -460,28 +517,33 @@ class ElectricalDesign(CableSystem):
         other_ancillary_cost : int | float
         """
 
-        backup_gen_cost = self._design.get("backup_gen_cost", 1e6)
-        workspace_cost = self._design.get("workspace_cost", 2e6)
-        other_ancillary_cost = self._design.get("other_ancillary_cost", 3e6)
+        _key = "backup_gen_cost"
+        if (
+            backup_gen_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        _key = "workspace_cost"
+        if (
+            workspace_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        _key = "other_ancillary_cost"
+        if (
+            other_ancillary_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         self.ancillary_system_costs = (
             backup_gen_cost + workspace_cost + other_ancillary_cost
         ) * self.num_substations
-
-    def calc_converter_cost(self):
-        """Computes converter cost."""
-
-        if self.cable.cable_type == "HVDC-monopole":
-            self.converter_cost = self.num_substations * self._design.get(
-                "converter_cost", 127e6
-            )
-
-        elif self.cable.cable_type == "HVDC-bipole":
-            self.converter_cost = self.num_substations * self._design.get(
-                "converter_cost", 296e6
-            )
-        else:
-            self.converter_cost = 0
 
     def calc_assembly_cost(self):
         """
@@ -492,9 +554,16 @@ class ElectricalDesign(CableSystem):
         topside_assembly_factor : int | float
         """
 
-        topside_assembly_factor = self.offshore_substation_design.get(
-            "topside_assembly_factor", 0.075
-        )
+        _key = "topside_assembly_factor"
+        if (
+            topside_assembly_factor := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        if topside_assembly_factor > 1.0:
+            topside_assembly_factor /= 100
 
         self.land_assembly_cost = (
             self.switchgear_cost
@@ -502,9 +571,26 @@ class ElectricalDesign(CableSystem):
             + self.ancillary_system_costs
         ) * topside_assembly_factor
 
+    def calc_converter_cost(self):
+        """Computes converter cost."""
+
+        _key = "converter_cost"
+        if (
+            converter_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        if isinstance(converter_cost, dict):
+            converter_cost = converter_cost[self.cable.cable_type]
+
+        self.converter_cost = converter_cost
+
     def calc_substructure_mass_and_cost(self):
         """
-        Calculates the mass and associated cost of the substation substructure.
+        Calculates the mass and associated cost of the substation substructure
+        based on equations 81-84 [1].
 
         Parameters
         ----------
@@ -512,26 +598,32 @@ class ElectricalDesign(CableSystem):
         oss_pile_cost_rate : int | float
         """
 
-        oss_pile_cost_rate = self.offshore_substation_design.get(
-            "oss_pile_cost_rate", 0
-        )
-        oss_substructure_cost_rate = self.offshore_substation_design.get(
-            "oss_substructure_cost_rate", 3000
-        )
+        _key = "oss_substructure_cost_rate"
+        if (
+            oss_substructure_cost_rate := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
-        # Substructure mass components calculated by curve fits in
-        # equations 81-84 from Maness et al. 2017
-        # https://www.nrel.gov/docs/fy17osti/66874.pdf
-        #
+        _key = "oss_pile_cost_rate"
+        if (
+            oss_pile_cost_rate := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        # Substructure mass components
         # TODO: Determine a better method to calculate substructure mass
         #       for different substructure types
         substructure_mass = 0.4 * self.topside_mass
 
-        if self.substructure_type == "Floating":
-            substructure_pile_mass = 0  # No piles used for floating platform
-
-        else:
-            substructure_pile_mass = 8 * substructure_mass**0.5574
+        substructure_pile_mass = (
+            0
+            if "Floating" in self.substructure_type
+            else 8 * substructure_mass**0.5574
+        )
 
         self.substructure_cost = (
             substructure_mass * oss_substructure_cost_rate
@@ -576,18 +668,23 @@ class ElectricalDesign(CableSystem):
         topside_design_cost: int | float
         """
 
-        _design = self.config.get("substation_design", {})
-
         self.topside_mass = (
             3.85 * (self.mpt_rating * self.num_mpt) / self.num_substations
             + 285
         )
-        if self.cable.cable_type == "HVDC-monopole":
-            self.topside_cost = _design.get("topside_design_cost", 294e6)
-        elif self.cable.cable_type == "HVDC-bipole":
-            self.topside_cost = _design.get("topside_design_cost", 476e6)
-        else:
-            self.topside_cost = _design.get("topside_design_cost", 107.3e6)
+
+        _key = "topside_design_cost"
+        if (
+            topside_design_cost := self._oss_design.get(
+                _key, oss_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        if isinstance(topside_design_cost, dict):
+            topside_design_cost = topside_design_cost[self.cable.cable_type]
+
+        self.topside_cost = topside_design_cost
 
     def calc_onshore_cost(self):
         """Minimum Cost of Onshore Substation Connection.
@@ -601,15 +698,62 @@ class ElectricalDesign(CableSystem):
 
         _design = self.config.get("onshore_substation_design", {})
 
-        _shunt_unit_cost = _design.get("shunt_unit_cost", 1.3e4)  # per cable
-        _switchgear_cost = _design.get("switchgear_cost", 9.33e6)  # per cable
-        _compensation_rate = _design.get(
-            "compensation_rate", 31.3e6
-        )  # per cable
+        if (
+            onshore_design_cost := common_costs.get(
+                "onshore_substation_design", None
+            )
+        ) is None:
+            raise KeyError("No onshore substation in common costs.")
+
+        _key = "shunt_unit_cost"
+        if (
+            _shunt_unit_cost := _design.get(
+                _key, onshore_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        _key = "switchgear_cost"
+        if (
+            _switchgear_cost := _design.get(
+                _key, onshore_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        _key = "compensation_rate"
+        if (
+            _compensation_rate := _design.get(
+                _key, onshore_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         self.onshore_shunt_reactor_cost = (
             self.compensation * self.num_cables * _shunt_unit_cost
         )
+
+        _key = "onshore_converter_cost"
+        if (
+            _converter_cost := _design.get(
+                _key, onshore_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        if isinstance(_converter_cost, dict):
+            _converter_cost = _converter_cost[self.cable_type.cable]
+
+        _key = "onshore_construction_rate"
+        if (
+            _construction_rate := _design.get(
+                _key, onshore_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
+        if isinstance(_construction_rate, dict):
+            _construction_rate = _construction_rate[self.cable_type.cable]
 
         if self.cable.cable_type == "HVDC-monopole":
             self.onshore_converter_cost = (

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -350,12 +350,12 @@ class ElectricalDesign(CableSystem):
         _crossing_design = self._design.get("cable_crossings", {})
 
         _key = "crossing_unit_cost"
-        if (
-            crossing_cost := _crossing_design.get(
-                _key, export_design_cost["cable_crossings"].get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        crossing_cost = _crossing_design.get(
+            _key,
+            self.get_default_cost(
+                "export_system_design", "cable_crossings", subkey=_key
+            ),
+        )
 
         self.crossing_cost = crossing_cost * _crossing_design.get(
             "crossing_number", 0
@@ -418,12 +418,9 @@ class ElectricalDesign(CableSystem):
         """
 
         _key = "mpt_unit_cost"
-        if (
-            _mpt_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        _mpt_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.num_mpt = self.num_cables
 
@@ -446,12 +443,10 @@ class ElectricalDesign(CableSystem):
         touchdown = self.config["site"]["distance_to_landfall"]
 
         _key = "shunt_unit_cost"
-        if (
-            shunt_unit_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+
+        shunt_unit_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         if "HVDC" in self.cable.cable_type:
             self.compensation = 0
@@ -472,12 +467,9 @@ class ElectricalDesign(CableSystem):
         """
 
         _key = "switchgear_cost"
-        if (
-            switchgear_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        switchgear_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         num_switchgear = (
             0 if "HVDC" in self.cable.cable_type else self.num_cables
@@ -494,12 +486,9 @@ class ElectricalDesign(CableSystem):
         """
 
         _key = "dc_breaker_cost"
-        if (
-            dc_breaker_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        dc_breaker_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         num_dc_breakers = (
             self.num_cables if "HVDC" in self.cable.cable_type else 0
@@ -519,28 +508,19 @@ class ElectricalDesign(CableSystem):
         """
 
         _key = "backup_gen_cost"
-        if (
-            backup_gen_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        backup_gen_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "workspace_cost"
-        if (
-            workspace_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        workspace_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "other_ancillary_cost"
-        if (
-            other_ancillary_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        other_ancillary_cost = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.ancillary_system_costs = (
             backup_gen_cost + workspace_cost + other_ancillary_cost
@@ -556,12 +536,9 @@ class ElectricalDesign(CableSystem):
         """
 
         _key = "topside_assembly_factor"
-        if (
-            topside_assembly_factor := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        topside_assembly_factor = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         if topside_assembly_factor > 1.0:
             topside_assembly_factor /= 100
@@ -576,15 +553,12 @@ class ElectricalDesign(CableSystem):
         """Computes converter cost."""
 
         _key = "converter_cost"
-        if (
-            converter_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
-        if isinstance(converter_cost, dict):
-            converter_cost = converter_cost[self.cable.cable_type]
+        converter_cost = self._oss_design.get(
+            _key,
+            self.get_default_cost(
+                "substation_design", _key, subkey=self.cable.cable_type
+            ),
+        )
 
         self.converter_cost = converter_cost
 
@@ -600,20 +574,14 @@ class ElectricalDesign(CableSystem):
         """
 
         _key = "oss_substructure_cost_rate"
-        if (
-            oss_substructure_cost_rate := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        oss_substructure_cost_rate = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "oss_pile_cost_rate"
-        if (
-            oss_pile_cost_rate := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        oss_pile_cost_rate = self._oss_design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         # Substructure mass components
         # TODO: Determine a better method to calculate substructure mass
@@ -675,15 +643,12 @@ class ElectricalDesign(CableSystem):
         )
 
         _key = "topside_design_cost"
-        if (
-            topside_design_cost := self._oss_design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
-        if isinstance(topside_design_cost, dict):
-            topside_design_cost = topside_design_cost[self.cable.cable_type]
+        topside_design_cost = self._oss_design.get(
+            _key,
+            self.get_default_cost(
+                "substation_design", _key, subkey=self.cable.cable_type
+            ),
+        )
 
         self.topside_cost = topside_design_cost
 
@@ -699,95 +664,54 @@ class ElectricalDesign(CableSystem):
 
         _design = self.config.get("onshore_substation_design", {})
 
-        if (
-            onshore_design_cost := common_costs.get(
-                "onshore_substation_design", None
-            )
-        ) is None:
-            raise KeyError("No onshore substation in common costs.")
+        _key = "onshore_converter_cost"
+        _converter_cost = _design.get(
+            _key,
+            self.get_default_cost(
+                "onshore_substation_design", _key, subkey=self.cable.cable_type
+            ),
+        )
 
-        _key = "shunt_unit_cost"
-        if (
-            _shunt_unit_cost := _design.get(
-                _key, onshore_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        self.onshore_converter_cost = self.num_substations * _converter_cost
 
         _key = "switchgear_cost"
-        if (
-            _switchgear_cost := _design.get(
-                _key, onshore_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        _switchgear_cost = _design.get(
+            _key, self.get_default_cost("onshore_substation_design", _key)
+        )
 
-        _key = "compensation_rate"
-        if (
-            _compensation_rate := _design.get(
-                _key, onshore_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        self.onshore_switchgear_cost = self.num_cables * _switchgear_cost
+
+        _key = "onshore_construction_rate"
+        _construction_rate = _design.get(
+            _key,
+            self.get_default_cost(
+                "onshore_substation_design", _key, subkey=self.cable.cable_type
+            ),
+        )
+
+        self.onshore_construction = self.num_substations * _construction_rate
+
+        _key = "shunt_unit_cost"
+        _shunt_unit_cost = _design.get(
+            _key, self.get_default_cost("onshore_substation_design", _key)
+        )
 
         self.onshore_shunt_reactor_cost = (
             self.compensation * self.num_cables * _shunt_unit_cost
         )
 
-        _key = "onshore_converter_cost"
-        if (
-            _converter_cost := _design.get(
-                _key, onshore_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        _key = "compensation_rate"
+        _compensation_rate = _design.get(
+            _key,
+            self.get_default_cost(
+                "onshore_substation_design", _key, subkey=self.cable.cable_type
+            ),
+        )
 
-        if isinstance(_converter_cost, dict):
-            _converter_cost = _converter_cost[self.cable.cable_type]
-
-        _key = "onshore_construction_rate"
-        if (
-            _construction_rate := _design.get(
-                _key, onshore_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
-        if isinstance(_construction_rate, dict):
-            _construction_rate = _construction_rate[self.cable.cable_type]
-
-        if self.cable.cable_type == "HVDC-monopole":
-            self.onshore_converter_cost = (
-                self.num_substations
-                * self._design.get("onshore_converter_cost", 157e6)
-            )
-            self.onshore_switchgear_cost = 0
-            self.onshore_construction = self.num_substations * _design.get(
-                "onshore_construction_rate", 87.3e6
-            )
-            self.onshore_compensation_cost = 0
-
-        elif self.cable.cable_type == "HVDC-bipole":
-            self.onshore_converter_cost = (
-                self.num_substations
-                * self._design.get("onshore_converter_cost", 350e6)
-            )
-            self.onshore_switchgear_cost = 0
-            self.onshore_construction = self.num_substations * _design.get(
-                "onshore_construction_rate", 100e6
-            )
-            self.onshore_compensation_cost = 0
-
-        else:
-            self.onshore_converter_cost = 0
-            self.onshore_switchgear_cost = self.num_cables * _switchgear_cost
-            self.onshore_construction = self.num_substations * _design.get(
-                "onshore_construction_rate", 5e6
-            )
-            self.onshore_compensation_cost = (
-                self.num_cables * _compensation_rate
-                + self.onshore_shunt_reactor_cost
-            )
+        self.onshore_compensation_cost = (
+            self.num_cables * _compensation_rate
+            + self.onshore_shunt_reactor_cost
+        )
 
         self.onshore_cost = (
             self.onshore_converter_cost

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -269,9 +269,6 @@ class ElectricalDesign(CableSystem):
         Calculate the total number of required and redundant cables to
         transmit power to the onshore interconnection.
 
-        Parameters
-        ----------
-        num_redundant : int
         """
 
         num_required = np.ceil(self._plant_capacity / self.cable.cable_power)
@@ -365,10 +362,6 @@ class ElectricalDesign(CableSystem):
     def calc_num_substations(self):
         """Computes number of substations based on HVDC or HVAC
         export cables.
-
-        Parameters
-        ----------
-        substation_capacity : int | float
         """
 
         # HVAC substation capacity
@@ -401,11 +394,8 @@ class ElectricalDesign(CableSystem):
         ) / self.num_substations
 
     def calc_mpt_cost(self):
-        """Computes HVAC main power transformer (MPT). MPT cost is 0 for HVDC.
-
-        Parameters
-        ----------
-        mpt_unit_cost : int | float
+        """Computes HVAC main power transformer (MPT). MPT cost is 0 for
+        HVDC.
         """
 
         _key = "mpt_unit_cost"
@@ -424,11 +414,8 @@ class ElectricalDesign(CableSystem):
         )
 
     def calc_shunt_reactor_cost(self):
-        """Computes HVAC shunt reactor cost. Shunt reactor cost is 0 for HVDC.
-
-        Parameters
-        ----------
-        shunt_unit_cost : int | float
+        """Computes HVAC shunt reactor cost. Shunt reactor cost is 0 for
+        HVDC.
         """
 
         touchdown = self.config["site"]["distance_to_landfall"]
@@ -450,12 +437,7 @@ class ElectricalDesign(CableSystem):
         )
 
     def calc_switchgear_costs(self):
-        """Computes HVAC switchgear cost. Switchgear cost is 0 for HVDC.
-
-        Parameters
-        ----------
-        switchgear_cost : int | float
-        """
+        """Computes HVAC switchgear cost. Switchgear cost is 0 for HVDC."""
 
         _key = "switchgear_cost"
         switchgear_cost = self._oss_design.get(
@@ -469,12 +451,7 @@ class ElectricalDesign(CableSystem):
         self.switchgear_cost = self.num_switchgear * switchgear_cost
 
     def calc_dc_breaker_cost(self):
-        """Computes HVDC circuit breaker cost. Breaker cost is 0 for HVAC.
-
-        Parameters
-        ----------
-        dc_breaker_cost : int | float
-        """
+        """Computes HVDC circuit breaker cost. Breaker cost is 0 for HVAC."""
 
         _key = "dc_breaker_cost"
         dc_breaker_cost = self._oss_design.get(
@@ -488,15 +465,7 @@ class ElectricalDesign(CableSystem):
         self.dc_breaker_cost = num_dc_breakers * dc_breaker_cost
 
     def calc_ancillary_system_cost(self):
-        """
-        Calculates cost of ancillary systems.
-
-        Parameters
-        ----------
-        backup_gen_cost : int | float
-        workspace_cost : int | float
-        other_ancillary_cost : int | float
-        """
+        """Calculates cost of ancillary systems."""
 
         _key = "backup_gen_cost"
         backup_gen_cost = self._oss_design.get(
@@ -518,13 +487,7 @@ class ElectricalDesign(CableSystem):
         ) * self.num_substations
 
     def calc_assembly_cost(self):
-        """
-        Calculates the cost of assembly on land.
-
-        Parameters
-        ----------
-        topside_assembly_factor : int | float
-        """
+        """Calculates the cost of assembly on land."""
 
         _key = "topside_assembly_factor"
         topside_assembly_factor = self._oss_design.get(
@@ -557,11 +520,6 @@ class ElectricalDesign(CableSystem):
         """
         Calculates the mass and associated cost of the substation substructure
         based on equations 81-84 [1].
-
-        Parameters
-        ----------
-        oss_substructure_cost_rate : int | float
-        oss_pile_cost_rate : int | float
         """
 
         _key = "oss_substructure_cost_rate"
@@ -620,13 +578,7 @@ class ElectricalDesign(CableSystem):
         self.topside_deck_space = 1
 
     def calc_topside_mass_and_cost(self):
-        """
-        Calculates the mass and cost of the substation topsides.
-
-        Parameters
-        ----------
-        topside_design_cost: int | float
-        """
+        """Calculates the mass and cost of the substation topsides."""
 
         self.topside_mass = (
             3.85 * (self.mpt_rating * self.num_mpt) / self.num_substations
@@ -644,14 +596,7 @@ class ElectricalDesign(CableSystem):
         self.topside_cost = topside_design_cost
 
     def calc_onshore_cost(self):
-        """Minimum Cost of Onshore Substation Connection.
-
-        Parameters
-        ----------
-        shunt_unit_cost : int | float
-        onshore_converter_cost: int | float
-        switchgear_cost: int | float
-        """
+        """Minimum Cost of Onshore Substation Connection."""
 
         _design = self.config.get("onshore_substation_design", {})
 

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -9,21 +9,12 @@ from warnings import warn
 
 import numpy as np
 
-from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design._cables import CableSystem
 
 """
 [1] Maness et al. 2017, NREL Offshore Balance-of-System Model.
 https://www.nrel.gov/docs/fy17osti/66874.pdf
 """
-
-if (
-    export_design_cost := common_costs.get("export_system_design", None)
-) is None:
-    raise KeyError("No export system in common costs.")
-
-if (oss_design_cost := common_costs.get("substation_design", None)) is None:
-    raise KeyError("No substation design in common costs.")
 
 
 class ElectricalDesign(CableSystem):
@@ -711,13 +702,6 @@ class ElectricalDesign(CableSystem):
         self.onshore_compensation_cost = (
             self.num_cables * _compensation_rate
             + self.onshore_shunt_reactor_cost
-        )
-        print(
-            f"converter: {self.onshore_converter_cost}"
-            f" switchgear: {self.onshore_switchgear_cost}"
-            f"construction:{self.onshore_construction}"
-            f" compensation: {self.onshore_compensation_cost}"
-            f" mpt_cost:{self.mpt_cost}"
         )
 
         self.onshore_cost = (

--- a/ORBIT/phases/design/monopile_design.py
+++ b/ORBIT/phases/design/monopile_design.py
@@ -13,6 +13,9 @@ from scipy.optimize import fsolve
 from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
 
+if (monopile_design_cost := common_costs.get("monopile_design", None)) is None:
+    raise KeyError("No spar_design in common costs.")
+
 
 class MonopileDesign(DesignPhase):
     """Monopile Design Class."""
@@ -75,6 +78,8 @@ class MonopileDesign(DesignPhase):
 
         config = self.initialize_library(config, **kwargs)
         self.config = self.validate_config(config)
+        self._design = self.config.get("monopile_design", {})
+
         self._outputs = {}
 
     def run(self):
@@ -306,14 +311,13 @@ class MonopileDesign(DesignPhase):
     def monopile_steel_cost(self):
         """Returns the cost of monopile steel (USD/t) fully fabricated."""
 
-        _design = self.config.get("monopile_design", {})
         _key = "monopile_steel_cost"
-
-        try:
-            cost = _design.get(_key, common_costs[_key])
-
-        except KeyError as exc:
-            raise Exception("Cost of monopile steel not found.") from exc
+        if (
+            cost := self._design.get(
+                _key, monopile_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         return cost
 
@@ -321,16 +325,13 @@ class MonopileDesign(DesignPhase):
     def tp_steel_cost(self):
         """Returns the cost of fabricated transition piece steel (USD/t)."""
 
-        _design = self.config.get("monopile_design", {})
         _key = "tp_steel_cost"
-
-        try:
-            cost = _design.get(_key, common_costs[_key])
-
-        except KeyError as exc:
-            raise Exception(
-                "Cost of transition piece steel not found."
-            ) from exc  # noqa: E501
+        if (
+            cost := self._design.get(
+                _key, monopile_design_cost.get(_key, None)
+            )
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
 
         return cost
 

--- a/ORBIT/phases/design/monopile_design.py
+++ b/ORBIT/phases/design/monopile_design.py
@@ -10,11 +10,7 @@ from math import pi, log
 
 from scipy.optimize import fsolve
 
-from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
-
-if (monopile_design_cost := common_costs.get("monopile_design", None)) is None:
-    raise KeyError("No monopile design in common costs.")
 
 
 class MonopileDesign(DesignPhase):

--- a/ORBIT/phases/design/monopile_design.py
+++ b/ORBIT/phases/design/monopile_design.py
@@ -312,12 +312,9 @@ class MonopileDesign(DesignPhase):
         """Returns the cost of monopile steel (USD/t) fully fabricated."""
 
         _key = "monopile_steel_cost"
-        if (
-            cost := self._design.get(
-                _key, monopile_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        cost = self._design.get(
+            _key, self.get_default_cost("monopile_design", _key)
+        )
 
         return cost
 
@@ -326,12 +323,9 @@ class MonopileDesign(DesignPhase):
         """Returns the cost of fabricated transition piece steel (USD/t)."""
 
         _key = "tp_steel_cost"
-        if (
-            cost := self._design.get(
-                _key, monopile_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        cost = self._design.get(
+            _key, self.get_default_cost("monopile_design", _key)
+        )
 
         return cost
 

--- a/ORBIT/phases/design/monopile_design.py
+++ b/ORBIT/phases/design/monopile_design.py
@@ -14,7 +14,7 @@ from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
 
 if (monopile_design_cost := common_costs.get("monopile_design", None)) is None:
-    raise KeyError("No spar_design in common costs.")
+    raise KeyError("No monopile design in common costs.")
 
 
 class MonopileDesign(DesignPhase):

--- a/ORBIT/phases/design/mooring_system_design.py
+++ b/ORBIT/phases/design/mooring_system_design.py
@@ -12,7 +12,6 @@ from math import sqrt
 
 from scipy.interpolate import interp1d
 
-from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
 
 """
@@ -22,11 +21,6 @@ https://www.nrel.gov/docs/fy17osti/66874.pdf
 [2] Cooperman et al. (2022), Assessment of Offshore Wind Energy Leasing Areas
 for Humboldt and Morry Bay. https://www.nrel.gov/docs/fy22osti/82341.pdf
 """
-
-if (
-    mooring_design_cost := common_costs.get("mooring_system_design", None)
-) is None:
-    raise KeyError("No mooring design in common costs.")
 
 
 class MooringSystemDesign(DesignPhase):
@@ -122,13 +116,14 @@ class MooringSystemDesign(DesignPhase):
         fit = -0.0004 * (tr**2) + 0.0132 * tr + 0.0536
 
         _key = "mooring_line_cost_rate"
-        if (
-            mooring_line_cost_rate := self._design.get(
-                _key, mooring_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
 
+        mooring_line_cost_rate = self._design.get(
+            _key,
+            self.get_default_cost(
+                "mooring_system_design",
+                _key,
+            ),
+        )
         if isinstance(mooring_line_cost_rate, (int, float)):
             mooring_line_cost_rate = [mooring_line_cost_rate] * 3
 
@@ -232,8 +227,8 @@ class MooringSystemDesign(DesignPhase):
         """
         Returns the mass and cost of anchors.
 
-        TODO: Anchor masses are rough estimates based on initial literature
-        review. Should be revised when this module is overhauled in the future.
+        TODO: Anchor masses are rough estimates based on [1]. Should be
+        revised when this module is overhauled in the future.
         TODO: Mooring types for Catenary, TLP, SemiTaut will likely have
         different anchors.
         """

--- a/ORBIT/phases/design/oss_design.py
+++ b/ORBIT/phases/design/oss_design.py
@@ -8,11 +8,7 @@ __email__ = "Jake.Nunemaker@nrel.gov"
 
 import numpy as np
 
-from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
-
-if (oss_design_cost := common_costs.get("substation_design", None)) is None:
-    raise KeyError("No substation design in common costs.")
 
 
 class OffshoreSubstationDesign(DesignPhase):

--- a/ORBIT/phases/design/oss_design.py
+++ b/ORBIT/phases/design/oss_design.py
@@ -36,6 +36,12 @@ class OffshoreSubstationDesign(DesignPhase):
             "oss_pile_cost_rate": "USD/t (optional)",
             "num_substations": "int (optional)",
         },
+        "export_system": {
+            "cable": {
+                "number": "int",
+                "cable_type": "str",
+            },
+        },
     }
 
     output_config = {
@@ -180,12 +186,9 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "mpt_cost_rate"
-        if (
-            mpt_cost_rate := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        mpt_cost_rate = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.mpt_cost = self.mpt_rating * self.num_mpt * mpt_cost_rate
 
@@ -200,20 +203,15 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "topside_fab_cost_rate"
-        if (
-            topside_fab_cost_rate := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        topside_fab_cost_rate = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "topside_design_cost"
-        if (
-            topside_design_cost := self._design.get(
-                _key, oss_design_cost[_key].get("HVAC", None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        topside_design_cost = self._design.get(
+            _key,
+            self.get_default_cost("substation_design", _key, subkey="HVAC"),
+        )
 
         self.topside_mass = 3.85 * self.mpt_rating * self.num_mpt + 285
         self.topside_cost = (
@@ -230,12 +228,9 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "shunt_cost_rate"
-        if (
-            shunt_cost_rate := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        shunt_cost_rate = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.shunt_reactor_cost = (
             self.mpt_rating * self.num_mpt * shunt_cost_rate * 0.5
@@ -251,12 +246,9 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "switchgear_cost"
-        if (
-            switchgear_cost_rate := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        switchgear_cost_rate = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.switchgear_costs = self.num_mpt * switchgear_cost_rate
 
@@ -272,28 +264,19 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "backup_gen_cost"
-        if (
-            backup_gen_cost := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        backup_gen_cost = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "workspace_cost"
-        if (
-            workspace_cost := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        workspace_cost = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "other_ancillary_cost"
-        if (
-            other_ancillary_cost := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        other_ancillary_cost = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.ancillary_system_costs = (
             backup_gen_cost + workspace_cost + other_ancillary_cost
@@ -309,12 +292,9 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "topside_assembly_factor"
-        if (
-            topside_assembly_factor := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        topside_assembly_factor = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         self.land_assembly_cost = (
             self.switchgear_costs
@@ -333,20 +313,14 @@ class OffshoreSubstationDesign(DesignPhase):
         """
 
         _key = "oss_substructure_cost_rate"
-        if (
-            oss_substructure_cost_rate := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        oss_substructure_cost_rate = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         _key = "oss_pile_cost_rate"
-        if (
-            oss_pile_cost_rate := self._design.get(
-                _key, oss_design_cost.get(_key, None)
-            )
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        oss_pile_cost_rate = self._design.get(
+            _key, self.get_default_cost("substation_design", _key)
+        )
 
         substructure_mass = 0.4 * self.topside_mass
         substructure_pile_mass = 8 * substructure_mass**0.5574

--- a/ORBIT/phases/design/oss_design.py
+++ b/ORBIT/phases/design/oss_design.py
@@ -32,12 +32,12 @@ class OffshoreSubstationDesign(DesignPhase):
             "oss_pile_cost_rate": "USD/t (optional)",
             "num_substations": "int (optional)",
         },
-        "export_system": {
-            "cable": {
-                "number": "int",
-                "cable_type": "str",
-            },
-        },
+        # "export_system": {
+        #    "cable": {
+        #        "number": "int",
+        #        "cable_type": "str",
+        #    },
+        # },
     }
 
     output_config = {

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -1,12 +1,22 @@
-"""Provides the `SemiSubmersibleDesign` class (from OffshoreBOS)."""
+"""Provides the `SemiSubmersibleDesign` class."""
 
 __author__ = "Jake Nunemaker"
 __copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
 __maintainer__ = "Jake Nunemaker"
 __email__ = "jake.nunemaker@nrel.gov"
 
-
+from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
+
+"""
+[1] Maness et al. 2017, NREL Offshore Balance-of-System Model.
+https://www.nrel.gov/docs/fy17osti/66874.pdf
+"""
+
+if (
+    semisub_design_cost := common_costs.get("semisubmersible_design", None)
+) is None:
+    raise KeyError("No spar_design in common costs.")
 
 
 class SemiSubmersibleDesign(DesignPhase):
@@ -61,53 +71,60 @@ class SemiSubmersibleDesign(DesignPhase):
 
     @property
     def stiffened_column_mass(self):
-        """
-        Calculates the mass of the stiffened column for a single
-        semi-submersible in tonnes. From original OffshoreBOS model.
+        """Calculates the mass of the stiffened column for a single
+        semi-submersible in tonnes [1].
         """
 
         rating = self.config["turbine"]["turbine_rating"]
+        mass = -0.9581 * rating**2 + 40.89 * rating + 802.09
         mass = -0.9581 * rating**2 + 40.89 * rating + 802.09
 
         return mass
 
     @property
     def stiffened_column_cost(self):
-        """
-        Calculates the cost of the stiffened column for a single
-        semi-submersible. From original OffshoreBOS model.
+        """Calculates the cost of the stiffened column for a single
+        semi-submersible [1].
         """
 
-        cr = self._design.get("stiffened_column_CR", 3120)
+        _key = "stiffened_column_CR"
+        if (
+            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
         return self.stiffened_column_mass * cr
 
     @property
     def truss_mass(self):
-        """
-        Calculates the truss mass for a single semi-submersible in tonnes. From
-        original OffshoreBOS model.
+        """Calculates the truss mass for a single semi-submersible in tonnes
+        [1].
         """
 
         rating = self.config["turbine"]["turbine_rating"]
+        mass = 2.7894 * rating**2 + 15.591 * rating + 266.03
         mass = 2.7894 * rating**2 + 15.591 * rating + 266.03
 
         return mass
 
     @property
     def truss_cost(self):
-        """
-        Calculates the cost of the truss for a signle semi-submerisble. From
-        original OffshoreBOS model.
+        """Calculates the cost of the truss for a signle semi-submerisble
+        [1].
         """
 
-        cr = self._design.get("truss_CR", 6250)
+        _key = "truss_CR"
+        if (
+            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
         return self.truss_mass * cr
 
     @property
     def heave_plate_mass(self):
-        """
-        Calculates the heave plate mass for a single semi-submersible in
-        tonnes. Source: original OffshoreBOS model.
+        """Calculates the heave plate mass for a single semi-submersible
+        in tonnes [1].
         """
 
         rating = self.config["turbine"]["turbine_rating"]
@@ -117,34 +134,42 @@ class SemiSubmersibleDesign(DesignPhase):
 
     @property
     def heave_plate_cost(self):
-        """
-        Calculates the heave plate cost for a single semi-submersible. From
-        original OffshoreBOS model.
+        """Calculates the heave plate cost for a single semi-submersible
+        [1].
         """
 
-        cr = self._design.get("heave_plate_CR", 6250)
+        _key = "heave_plate_CR"
+        if (
+            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
         return self.heave_plate_mass * cr
 
     @property
     def secondary_steel_mass(self):
-        """
-        Calculates the mass of the required secondary steel for a single
-        semi-submersible. From original OffshoreBOS model.
+        """Calculates the mass of the required secondary steel for a single
+        semi-submersible [1].
         """
 
         rating = self.config["turbine"]["turbine_rating"]
+        mass = -0.153 * rating**2 + 6.54 * rating + 128.34
         mass = -0.153 * rating**2 + 6.54 * rating + 128.34
 
         return mass
 
     @property
     def secondary_steel_cost(self):
-        """
-        Calculates the cost of the required secondary steel for a single
-        semi-submersible. For original OffshoreBOS model.
+        """Calculates the cost of the required secondary steel for a single
+        semi-submersible [1].
         """
 
-        cr = self._design.get("secondary_steel_CR", 7250)
+        _key = "secondary_steel_CR"
+        if (
+            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
+        ) is None:
+            raise KeyError(f"{_key} not found in common_costs.")
+
         return self.secondary_steel_mass * cr
 
     @property

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -5,18 +5,12 @@ __copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
 __maintainer__ = "Jake Nunemaker"
 __email__ = "jake.nunemaker@nrel.gov"
 
-from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
 
 """
 [1] Maness et al. 2017, NREL Offshore Balance-of-System Model.
 https://www.nrel.gov/docs/fy17osti/66874.pdf
 """
-
-if (
-    semisub_design_cost := common_costs.get("semisubmersible_design", None)
-) is None:
-    raise KeyError("No semisub design in common costs.")
 
 
 class SemiSubmersibleDesign(DesignPhase):
@@ -88,11 +82,9 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         _key = "stiffened_column_CR"
-        if (
-            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
+        cr = self._design.get(
+            _key, self.get_default_cost("semisubmersible_design", _key)
+        )
         return self.stiffened_column_mass * cr
 
     @property
@@ -114,11 +106,9 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         _key = "truss_CR"
-        if (
-            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
+        cr = self._design.get(
+            _key, self.get_default_cost("semisubmersible_design", _key)
+        )
         return self.truss_mass * cr
 
     @property
@@ -139,11 +129,9 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         _key = "heave_plate_CR"
-        if (
-            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
+        cr = self._design.get(
+            _key, self.get_default_cost("semisubmersible_design", _key)
+        )
         return self.heave_plate_mass * cr
 
     @property
@@ -165,11 +153,9 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         _key = "secondary_steel_CR"
-        if (
-            cr := self._design.get(_key, semisub_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
-
+        cr = self._design.get(
+            _key, self.get_default_cost("semisubmersible_design", _key)
+        )
         return self.secondary_steel_mass * cr
 
     @property

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -16,7 +16,7 @@ https://www.nrel.gov/docs/fy17osti/66874.pdf
 if (
     semisub_design_cost := common_costs.get("semisubmersible_design", None)
 ) is None:
-    raise KeyError("No spar_design in common costs.")
+    raise KeyError("No semisub design in common costs.")
 
 
 class SemiSubmersibleDesign(DesignPhase):

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -70,7 +70,7 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         rating = self.config["turbine"]["turbine_rating"]
-        mass = -0.9581 * rating**2 + 40.89 * rating + 802.09
+
         mass = -0.9581 * rating**2 + 40.89 * rating + 802.09
 
         return mass
@@ -94,7 +94,7 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         rating = self.config["turbine"]["turbine_rating"]
-        mass = 2.7894 * rating**2 + 15.591 * rating + 266.03
+
         mass = 2.7894 * rating**2 + 15.591 * rating + 266.03
 
         return mass
@@ -118,6 +118,7 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         rating = self.config["turbine"]["turbine_rating"]
+
         mass = -0.4397 * rating**2 + 21.545 * rating + 177.42
 
         return mass
@@ -141,7 +142,7 @@ class SemiSubmersibleDesign(DesignPhase):
         """
 
         rating = self.config["turbine"]["turbine_rating"]
-        mass = -0.153 * rating**2 + 6.54 * rating + 128.34
+
         mass = -0.153 * rating**2 + 6.54 * rating + 128.34
 
         return mass

--- a/ORBIT/phases/design/spar_design.py
+++ b/ORBIT/phases/design/spar_design.py
@@ -17,7 +17,7 @@ https://www.nrel.gov/docs/fy17osti/66874.pdf
 """
 
 if (spar_design_cost := common_costs.get("spar_design", None)) is None:
-    raise KeyError("No spar_design in common costs.")
+    raise KeyError("No spar design in common costs.")
 
 
 class SparDesign(DesignPhase):

--- a/ORBIT/phases/design/spar_design.py
+++ b/ORBIT/phases/design/spar_design.py
@@ -105,10 +105,12 @@ class SparDesign(DesignPhase):
         """
 
         _key = "stiffened_column_CR"
-        if (
-            cr := self._design.get(_key, spar_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        cr = self._design.get(_key, self.set_default_cost("spar_design", _key))
+
+        # if (
+        #    cr := self._design.get(_key, spar_design_cost.get(_key, None))
+        # ) is None:
+        #    raise KeyError(f"{_key} not found in common_costs.")
 
         return self.stiffened_column_mass * cr
 

--- a/ORBIT/phases/design/spar_design.py
+++ b/ORBIT/phases/design/spar_design.py
@@ -8,16 +8,12 @@ __email__ = "jake.nunemaker@nrel.gov"
 
 from numpy import exp, log
 
-from ORBIT.core.defaults import common_costs
 from ORBIT.phases.design import DesignPhase
 
 """
 [1] Maness et al. 2017, NREL Offshore Balance-of-System Model.
 https://www.nrel.gov/docs/fy17osti/66874.pdf
 """
-
-if (spar_design_cost := common_costs.get("spar_design", None)) is None:
-    raise KeyError("No spar design in common costs.")
 
 
 class SparDesign(DesignPhase):
@@ -105,12 +101,7 @@ class SparDesign(DesignPhase):
         """
 
         _key = "stiffened_column_CR"
-        cr = self._design.get(_key, self.set_default_cost("spar_design", _key))
-
-        # if (
-        #    cr := self._design.get(_key, spar_design_cost.get(_key, None))
-        # ) is None:
-        #    raise KeyError(f"{_key} not found in common_costs.")
+        cr = self._design.get(_key, self.get_default_cost("spar_design", _key))
 
         return self.stiffened_column_mass * cr
 
@@ -119,10 +110,7 @@ class SparDesign(DesignPhase):
         """Calculates the cost of the tapered column for a single spar [1]."""
 
         _key = "tapered_column_CR"
-        if (
-            cr := self._design.get(_key, spar_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        cr = self._design.get(_key, self.get_default_cost("spar_design", _key))
 
         return self.tapered_column_mass * cr
 
@@ -141,11 +129,7 @@ class SparDesign(DesignPhase):
         """Calculates the cost of ballast material for a single spar [1]."""
 
         _key = "ballast_material_CR"
-
-        if (
-            cr := self._design.get(_key, spar_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        cr = self._design.get(_key, self.get_default_cost("spar_design", _key))
 
         return self.ballast_mass * cr
 
@@ -174,10 +158,7 @@ class SparDesign(DesignPhase):
         """
 
         _key = "secondary_steel_CR"
-        if (
-            cr := self._design.get(_key, spar_design_cost.get(_key, None))
-        ) is None:
-            raise KeyError(f"{_key} not found in common_costs.")
+        cr = self._design.get(_key, self.get_default_cost("spar_design", _key))
 
         return self.secondary_steel_mass * cr
 

--- a/ORBIT/phases/design/spar_design.py
+++ b/ORBIT/phases/design/spar_design.py
@@ -78,7 +78,6 @@ class SparDesign(DesignPhase):
         depth = self.config["site"]["depth"]
 
         mass = 535.93 + 17.664 * rating**2 + 0.02328 * depth * log(depth)
-        mass = 535.93 + 17.664 * rating**2 + 0.02328 * depth * log(depth)
 
         return mass
 
@@ -119,7 +118,7 @@ class SparDesign(DesignPhase):
         """Calculates the ballast mass of a single spar [1]."""
 
         rating = self.config["turbine"]["turbine_rating"]
-        mass = -16.536 * rating**2 + 1261.8 * rating - 1554.6
+
         mass = -16.536 * rating**2 + 1261.8 * rating - 1554.6
 
         return mass
@@ -144,7 +143,6 @@ class SparDesign(DesignPhase):
 
         mass = exp(
             3.58
-            + 0.196 * (rating**0.5) * log(rating)
             + 0.196 * (rating**0.5) * log(rating)
             + 0.00001 * depth * log(depth)
         )

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ ORBIT Changelog
 
 Unreleased (TBD)
 ----------------
+- Relocated all the get design costs in each design class to `common_cost.yaml`. Spar, Semisub, monopile, electrical, offshore substation, and mooring designs all recieved this update.
 
 Merged SemiTaut Moorings
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -290,18 +290,21 @@ def test_onshore_substation():
     config = deepcopy(base)
     elect = ElectricalDesign(config)
     elect.run()
+    assert elect.onshore_compensation_cost != 0.0
     assert elect.onshore_cost == pytest.approx(95.487e6, abs=1e2)  # 109.32e6
 
     config_mono = deepcopy(config)
     config_mono["export_system_design"] = {"cables": "HVDC_2000mm_320kV"}
     o_monelect = ElectricalDesign(config_mono)
     o_monelect.run()
-    assert o_monelect.onshore_cost == 244.3e6
+    assert o_monelect.onshore_compensation_cost == 0.0
+    # assert o_monelect.onshore_cost == 244.3e6
 
     config_bi = deepcopy(config)
     config_bi["export_system_design"] = {"cables": "HVDC_2500mm_525kV"}
     o_bi = ElectricalDesign(config_bi)
     o_bi.run()
+    assert o_bi.onshore_compensation_cost == 0.0
     assert o_bi.onshore_cost == 450e6
 
 

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -238,7 +238,7 @@ def test_calc_topside_mass_and_cost():
     assert elec._outputs["num_substations"] == 1
     assert elec._outputs["offshore_substation_topside"][
         "unit_cost"
-    ] == pytest.approx(23673542.01, abs=1)
+    ] == pytest.approx(23673542, abs=1e2)
 
 
 def test_new_old_hvac_substation():

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -244,6 +244,8 @@ def test_new_old_hvac_substation():
     config["plant"]["num_turbines"] = 200
     config["turbine"] = {"turbine_rating": 5}
 
+    config["export_system"] = {"cable": {"number": 5, "cable_type": "HVAC"}}
+
     new = ElectricalDesign(config)
     new.run()
 

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -68,9 +68,8 @@ def test_parameter_sweep(distance_to_landfall, depth, plant_cap, cable):
 
 
 def test_detailed_design_length():
-    """
-    Ensure that the same # of output variables are used for a floating and
-    fixed offshore substation.
+    """Ensure that the same # of output variables are used for a floating
+    and fixed offshore substation.
     """
 
     elect = ElectricalDesign(base)
@@ -104,32 +103,50 @@ def test_calc_substructure_mass_and_cost():
     )
 
 
-def test_calc_topside_mass_and_cost():
-    """
-    Test topside mass and cost for HVDC compared to HVDC-Monopole and
-    HVDC-Bipole.
-    """
+"""def test_calc_topside_mass_and_cost():
+    #Test topside mass and cost for HVDC compared to HVDC-Monopole and
+    #HVDC-Bipole.
+    #
 
     elect = ElectricalDesign(base)
     elect.run()
 
-    base_dc = deepcopy(base)
-    cables = ["HVDC_2000mm_320kV", "HVDC_2500mm_525kV"]
+    mono_dc = deepcopy(base)
+    mono_dc["export_system_design"]["cables"] = "HVDC_2000mm_320kV"
+    elect_mono = ElectricalDesign(mono_dc)
+    elect_mono.run()
 
-    for cable in cables:
-        base_dc["export_system_design"]["cables"] = cable
+    assert (
+        elect.detailed_output["substation_topside_mass"]
+        == elect_mono.detailed_output["substation_topside_mass"]
+    )
+    assert (
+        elect.detailed_output["substation_topside_cost"]
+        != elect_mono.detailed_output["substation_topside_cost"]
+    )
 
-        elect_dc = ElectricalDesign(base_dc)
-        elect_dc.run()
+    bi_dc = deepcopy(base)
+    bi_dc["export_system_design"]["cables"] = "HVDC_2500mm_525kV"
+    elect_bi = ElectricalDesign(bi_dc)
+    elect_bi.run()
 
-        assert (
-            elect.detailed_output["substation_topside_mass"]
-            == elect_dc.detailed_output["substation_topside_mass"]
-        )
-        assert (
-            elect.detailed_output["substation_topside_cost"]
-            != elect_dc.detailed_output["substation_topside_cost"]
-        )
+    assert (
+        elect.detailed_output["substation_topside_mass"]
+        == elect_bi.detailed_output["substation_topside_mass"]
+    )
+    assert (
+        elect.detailed_output["substation_topside_cost"]
+        != elect_bi.detailed_output["substation_topside_cost"]
+    )
+
+    assert (
+        elect_bi.detailed_output["substation_topside_mass"]
+        == elect_mono.detailed_output["substation_topside_mass"]
+    )
+    assert (
+        elect_bi.detailed_output["substation_topside_cost"]
+        != elect_mono.detailed_output["substation_topside_cost"]
+    )"""
 
 
 def test_oss_substructure_kwargs():
@@ -209,6 +226,19 @@ def test_dc_oss_kwargs():
         cost = elect.detailed_output["total_substation_cost"]
 
         assert cost != base_cost
+
+
+def test_calc_topside_mass_and_cost():
+
+    config = deepcopy(base)
+    config["substation_design"]["topside_design_cost"] = 9999.9
+    elec = ElectricalDesign(config)
+    elec.run()
+
+    assert elec._outputs["num_substations"] == 1
+    assert elec._outputs["offshore_substation_topside"][
+        "unit_cost"
+    ] == pytest.approx(23673542.01, abs=1)
 
 
 def test_new_old_hvac_substation():

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -103,13 +103,20 @@ def test_calc_substructure_mass_and_cost():
     )
 
 
-"""def test_calc_topside_mass_and_cost():
-    #Test topside mass and cost for HVDC compared to HVDC-Monopole and
-    #HVDC-Bipole.
+def test_calc_topside_mass_and_cost():
+    # Test topside mass and cost for HVDC compared to HVDC-Monopole and
+    # HVDC-Bipole.
     #
 
-    elect = ElectricalDesign(base)
+    config = deepcopy(base)
+    config["substation_design"]["topside_design_cost"] = 9999.9
+    elect = ElectricalDesign(config)
     elect.run()
+
+    assert elect._outputs["num_substations"] == 1
+    assert elect._outputs["offshore_substation_topside"][
+        "unit_cost"
+    ] == pytest.approx(23683541, abs=1e2)
 
     mono_dc = deepcopy(base)
     mono_dc["export_system_design"]["cables"] = "HVDC_2000mm_320kV"
@@ -146,7 +153,7 @@ def test_calc_substructure_mass_and_cost():
     assert (
         elect_bi.detailed_output["substation_topside_cost"]
         != elect_mono.detailed_output["substation_topside_cost"]
-    )"""
+    )
 
 
 def test_oss_substructure_kwargs():
@@ -226,19 +233,6 @@ def test_dc_oss_kwargs():
         cost = elect.detailed_output["total_substation_cost"]
 
         assert cost != base_cost
-
-
-def test_calc_topside_mass_and_cost():
-
-    config = deepcopy(base)
-    config["substation_design"]["topside_design_cost"] = 9999.9
-    elec = ElectricalDesign(config)
-    elec.run()
-
-    assert elec._outputs["num_substations"] == 1
-    assert elec._outputs["offshore_substation_topside"][
-        "unit_cost"
-    ] == pytest.approx(23673542, abs=1e2)
 
 
 def test_new_old_hvac_substation():

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -298,7 +298,7 @@ def test_onshore_substation():
     o_monelect = ElectricalDesign(config_mono)
     o_monelect.run()
     assert o_monelect.onshore_compensation_cost == 0.0
-    # assert o_monelect.onshore_cost == 244.3e6
+    assert o_monelect.onshore_cost == 244.3e6
 
     config_bi = deepcopy(config)
     config_bi["export_system_design"] = {"cables": "HVDC_2500mm_525kV"}

--- a/tests/phases/design/test_oss_design.py
+++ b/tests/phases/design/test_oss_design.py
@@ -16,6 +16,7 @@ base = {
     "plant": {"num_turbines": 50},
     "turbine": {"turbine_rating": 6},
     "substation_design": {},
+    "export_system": {"cable": {"number": 3, "cable_type": "HVAC"}},
 }
 
 
@@ -30,6 +31,7 @@ def test_parameter_sweep(depth, num_turbines, turbine_rating):
         "plant": {"num_turbines": num_turbines},
         "turbine": {"turbine_rating": turbine_rating},
         "substation_design": {},
+        "export_system": {"cable": {"number": 3, "cable_type": "HVAC"}},
     }
 
     o = OffshoreSubstationDesign(config)


### PR DESCRIPTION
Several design modules employ common costs or cost rates for different components if the user does not specify their own value. While this only takes up about 1 line per call, the downside is that default values scattered among the design modules. This pull request reorganizes all those default values into ORBIT/core/default/common_cost.yaml so they can be more easily accessed and managed. Additionally, extra logic was incorporated to catch KeyErrors. 