### PR TITLE
New feature: Custom Semisubmersible design 

### DIFF
--- a/ORBIT/phases/design/__init__.py
+++ b/ORBIT/phases/design/__init__.py
@@ -16,5 +16,8 @@ from .oss_design_floating import OffshoreFloatingSubstationDesign
 from .export_system_design import ExportSystemDesign
 from .mooring_system_design import MooringSystemDesign
 from .scour_protection_design import ScourProtectionDesign
-from .semi_submersible_design import SemiSubmersibleDesign
+from .semi_submersible_design import (
+    SemiSubmersibleDesign,
+    CustomSemiSubmersibleDesign,
+)
 from .SemiTaut_mooring_system_design import SemiTautMooringSystemDesign

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -329,7 +329,7 @@ class CustomSemiSubmersibleDesign(DesignPhase):
     @property
     def center_column_volume(self):
         """
-        Returns the volume of a hollow column between turbine and
+        Returns the volume of a hollow cylindrical column between turbine and
         pontoons, assuming wall-thickness remains constant [2].
         """
 
@@ -377,14 +377,6 @@ class CustomSemiSubmersibleDesign(DesignPhase):
         # TODO: Separate out different steels for each component
 
         density = self._design.get("steel_density", 7980)
-
-        print(
-            "Volumes: ",
-            self.bouyant_column_volume,
-            self.center_column_volume,
-            self.pontoon_volume,
-            self.strut_volume,
-        )
 
         return (density / 1000) * (
             self.num_columns * self.bouyant_column_volume

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -290,6 +290,8 @@ class CustomSemiSubmersibleDesign(DesignPhase):
     def run(self):
         """Main run function."""
 
+        self.calc_geometric_scale_factor()
+
         substructure = {
             "mass": self.substructure_mass,
             "unit_cost": self.substructure_unit_cost,
@@ -381,17 +383,17 @@ class CustomSemiSubmersibleDesign(DesignPhase):
 
         print(
             "Volumes: ",
-            self.num_column * self.bouyant_column_volume,
+            self.bouyant_column_volume,
             self.center_column_volume,
-            self.num_column * self.pontoon_volume,
-            self.num_column * self.strut_volume,
+            self.pontoon_volume,
+            self.strut_volume,
         )
 
         return (density / 1000) * (
-            self.num_column * self.bouyant_column_volume
+            self.num_columns * self.bouyant_column_volume
             + self.center_column_volume
-            + self.num_column * self.pontoon_volume
-            + self.num_column * self.strut_volume
+            + self.num_columns * self.pontoon_volume
+            + self.num_columns * self.strut_volume
         )
 
     @property
@@ -429,9 +431,11 @@ class CustomSemiSubmersibleDesign(DesignPhase):
         """
 
         return sum(
-            self.substructure_steel_mass,
-            self.ballast_mass,
-            self.tower_interface_mass,
+            [
+                self.substructure_steel_mass,
+                self.ballast_mass,
+                self.tower_interface_mass,
+            ]
         )
 
     @property

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
 __maintainer__ = "Jake Nunemaker"
 __email__ = "jake.nunemaker@nrel.gov"
 
+import numpy as np
 
 from ORBIT.phases.design import DesignPhase
 
@@ -217,10 +218,6 @@ __copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
 __maintainer__ = "Nick Riccobono"
 __email__ = "nicholas.riccobono@nrel.gov"
 
-import numpy as np
-
-from ORBIT.phases.design import DesignPhase
-
 """
 Based on semisub design from 15 MW RWT
 
@@ -255,9 +252,9 @@ class CustomSemiSubmersibleDesign(DesignPhase):
             "pontoon_height": "m (optional, default: 7)",
             "strut_diameter": "m (optional, 0.9)",
             "steel_density": "kg/m^3 (optional, default: 7980)",
-            "ballast_mass": "tonnes (optional, default 0)",
+            "ballast_mass": "tonnes (optional, default 2540)",
             "tower_interface_mass": "tonnes (optional, default 100)",
-            "steel_cost_rate": "$/tonne (optional, default: 4500)",
+            "steel_CR": "$/tonne (optional, default: 4500)",
             "ballast_material_CR": "$/tonne (optional, default: 150)",
         },
     }
@@ -419,7 +416,7 @@ class CustomSemiSubmersibleDesign(DesignPhase):
         in $USD.
         """
 
-        self.steel_cr = self._design.get("steel_cost_rate", 4500)
+        self.steel_cr = self._design.get("steel_CR", 4500)
 
         return self.steel_cr * self.substructure_steel_mass
 
@@ -445,7 +442,7 @@ class CustomSemiSubmersibleDesign(DesignPhase):
         Does not include final assembly or transportation costs.
         """
 
-        ballast_cr = self._design.get("ballast_cost_rate", 150)
+        ballast_cr = self._design.get("ballast_material_CR", 150)
 
         return (
             self.substructure_steel_cost

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -303,7 +303,10 @@ class CustomSemiSubmersibleDesign(DesignPhase):
         Lines 335-340 [2].
         """
 
-        turbine_radius = float(self.config["turbine"]["rotor_diameter"] / 2)
+        turbine_diameter = self.config["turbine"].get("rotor_diameter")
+
+        if turbine_diameter is None:
+            raise KeyError("Turbine rotor diameter not specified.")
 
         # IEA-15MW 120m radius
         ref_radius = kwargs.get("ref_radius", 120.0)
@@ -311,7 +314,9 @@ class CustomSemiSubmersibleDesign(DesignPhase):
         # power-law parameter
         alpha = kwargs.get("alpha", 0.72)
 
-        self.geom_scale_factor = (turbine_radius / ref_radius) ** alpha
+        self.geom_scale_factor = (
+            float(turbine_diameter) / 2 / ref_radius
+        ) ** alpha
 
     @property
     def bouyant_column_volume(self):

--- a/ORBIT/phases/design/semi_submersible_design.py
+++ b/ORBIT/phases/design/semi_submersible_design.py
@@ -208,3 +208,268 @@ class SemiSubmersibleDesign(DesignPhase):
         }
 
         return _outputs
+
+
+"""Provides the `CustomSemiSubmersibleDesign` class."""
+
+__author__ = "Matt Shields"
+__copyright__ = "Copyright 2020, National Renewable Energy Laboratory"
+__maintainer__ = "Nick Riccobono"
+__email__ = "nicholas.riccobono@nrel.gov"
+
+import numpy as np
+
+from ORBIT.phases.design import DesignPhase
+
+"""
+Based on semisub design from 15 MW RWT
+
+[1]	C. Allen et al., “Definition of the UMaine VolturnUS-S Reference Platform
+ Developed for the IEA Wind 15-Megawatt Offshore Reference Wind Turbine,”
+ NREL/TP--5000-76773, 1660012, MainId:9434, Jul. 2020. doi: 10.2172/1660012.
+[2]	K. L. Roach, M. A. Lackner, and J. F. Manwell, “A New Methodology for
+ Upscaling Semi-submersible Platforms for Floating Offshore Wind Turbines,”
+ Wind Energy Science Discussions, pp. 1–33, Feb. 2023,
+ doi: 10.5194/wes-2023-18.
+"""
+
+
+class CustomSemiSubmersibleDesign(DesignPhase):
+    """Customized Semi-Submersible Substructure Design."""
+
+    expected_config = {
+        "site": {"depth": "m"},
+        "plant": {"num_turbines": "int"},
+        "turbine": {"turbine_rating": "MW"},
+        "semisubmersible_design": {
+            "stiffened_column_CR": "$/t (optional, default: 3120)",
+            "truss_CR": "$/t (optional, default: 6250)",
+            "heave_plate_CR": "$/t (optional, default: 6250)",
+            "secondary_steel_CR": "$/t (optional, default: 7250)",
+            "towing_speed": "km/h (optional, default: 6)",
+            "column_diameter": "m",
+            "wall_thickness": "m",
+            "column_height": "m",
+            "pontoon_length": "m",
+            "pontoon_width": "m",
+            "pontoon_height": "m",
+            "strut_diameter": "m",
+            "steel_density": "kg/m^3 (optional, default: 8050)",
+            "ballast_mass": "tonnes (optional, default 0)",
+            "tower_interface_mass": "tonnes (optional, default 100)",
+            "steel_cost_rate": "$/tonne (optional, default: 4500)",
+            "ballast_material_CR": "$/tonne (optional, default: 150)",
+        },
+    }
+
+    output_config = {
+        "substructure": {
+            "mass": "t",
+            "unit_cost": "USD",
+            "towing_speed": "km/h",
+        }
+    }
+
+    def __init__(self, config, **kwargs):
+        """
+        Creates an instance of `CustomSemiSubmersibleDesign`.
+
+        Parameters
+        ----------
+        config : dict
+        """
+
+        config = self.initialize_library(config, **kwargs)
+        self.config = self.validate_config(config)
+        self._design = self.config.get("semisubmersible_design", {})
+
+        self.num_columns = kwargs.get("number_columns", 3)
+
+        self._outputs = {}
+
+    def run(self):
+        """Main run function."""
+
+        substructure = {
+            "mass": self.substructure_mass,
+            "unit_cost": self.substructure_unit_cost,
+            "towing_speed": self._design.get("towing_speed", 6),
+        }
+
+        self._outputs["substructure"] = substructure
+
+    def calc_geometric_scale_factor(self, **kwargs):
+        """Calculates the geometric factor to scale the size of the semi-
+        submersible. Upscaling methodology and parameters used are found on
+        Lines 335-340 [2].
+        """
+
+        turbine_radius = float(self.config["turbine"]["rotor_diameter"] / 2)
+
+        # IEA-15MW 120m radius
+        ref_radius = kwargs.get("ref_radius", 120.0)
+
+        # power-law parameter
+        alpha = kwargs.get("alpha", 0.72)
+
+        self.geom_scale_factor = (turbine_radius / ref_radius) ** alpha
+
+    @property
+    def bouyant_column_volume(self):
+        """
+        Returns the volume of a capped, hollow, cylindrical column,
+        assuming the wall-thickness remains constant [2].
+        """
+
+        dc = self._design["column_diameter"] * self.geom_scale_factor
+        hc = self._design["column_height"] * self.geom_scale_factor
+        tc = self._design["wall_thickness"]
+
+        return (np.pi / 4) * (hc * dc**2 - (hc - 2 * tc) * (dc - 2 * tc) ** 2)
+
+    @property
+    def center_column_volume(self):
+        """
+        Returns the volume of a hollow column between turbine and
+        pontoons, assuming wall-thickness remains constant [2].
+        """
+
+        dc = 10.0  # fixed tower diameter
+        hc = self._design["column_height"] * self.geom_scale_factor
+        hp = self._design["pontoon_height"] * self.geom_scale_factor
+        tc = self._design["wall_thickness"]
+
+        return (np.pi / 4) * (
+            (hc - hp) * dc**2 - (hc - hp) * (dc - 2 * tc) ** 2
+        )
+
+    @property
+    def pontoon_volume(self):
+        """
+        Returns the volume of a single hollow rectangular pontoon that connects
+        the central column to the outer columns, assuming wall-thickness
+        reamins constant [2].
+        """
+        # TODO: Subtract semi-circular area from fairlead column?
+
+        lp = self._design["pontoon_length"] * self.geom_scale_factor
+        wp = self._design["pontoon_width"] * self.geom_scale_factor
+        hp = self._design["pontoon_height"] * self.geom_scale_factor
+        tp = self._design["wall_thickness"]
+
+        return (hp * wp - (hp - 2 * tp) * (wp - 2 * tp)) * lp
+
+    @property
+    def strut_volume(self):
+        """
+        Returns the volume of a single solid strut that connects
+        the central column to the outer columns.
+        """
+
+        lp = self._design["pontoon_length"] * self.geom_scale_factor
+        ds = self._design["strut_diameter"] * self.geom_scale_factor
+
+        return (np.pi / 4) * (ds**2) * lp
+
+    @property
+    def substructure_steel_mass(self):
+        """Returns the total mass of structural steel in the substructure."""
+
+        # TODO: Separate out different steels for each component
+
+        density = self._design.get("steel_density", 7980)
+
+        print(
+            "Volumes: ",
+            self.num_column * self.bouyant_column_volume,
+            self.center_column_volume,
+            self.num_column * self.pontoon_volume,
+            self.num_column * self.strut_volume,
+        )
+
+        return (density / 1000) * (
+            self.num_column * self.bouyant_column_volume
+            + self.center_column_volume
+            + self.num_column * self.pontoon_volume
+            + self.num_column * self.strut_volume
+        )
+
+    @property
+    def ballast_mass(self):
+        """Returns the mass of fixed ballast. Default value from [1]."""
+        # TODO: Scale ballast mass with some factor?
+        # Fixed/Fluid needs to be addressed because 11,300t of seawater is used
+        # to submerge the platform.
+
+        return self._design.get("ballast_mass", 2540)
+
+    @property
+    def tower_interface_mass(self):
+        """Returns the mass of tower interface. Default value from [1]."""
+
+        # TODO: Find a model to estimate the mass for a tower interface
+
+        return self._design.get("tower_interface_mass", 100)
+
+    @property
+    def substructure_steel_cost(self):
+        """Returns the total cost of structural steel of the substructure
+        in $USD.
+        """
+
+        steel_cr = self._design.get("steel_cost_rate", 4500)
+
+        return steel_cr * self.substructure_steel_mass
+
+    @property
+    def substructure_mass(self):
+        """
+        Returns the total mass of structural steel and iron ore ballast
+        in the substructure.
+        """
+
+        return sum(
+            self.substructure_steel_mass,
+            self.ballast_mass,
+            self.tower_interface_mass,
+        )
+
+    @property
+    def substructure_unit_cost(self):
+        """
+        Returns the total material cost of a single substructure.
+        Does not include final assembly or transportation costs.
+        """
+
+        ballast_cr = self._design.get("ballast_cost_rate", 150)
+
+        return self.substructure_steel_cost + ballast_cr * self.ballast_mass
+
+    @property
+    def design_result(self):
+        """Returns the result of `self.run()`."""
+
+        if not self._outputs:
+            raise Exception("Has `CustomSemiSubmersibleDesign` been ran yet?")
+
+        return self._outputs
+
+    @property
+    def total_cost(self):
+        """Returns total phase cost in $USD."""
+
+        num = self.config["plant"]["num_turbines"]
+        return num * self.substructure_unit_cost
+
+    @property
+    def detailed_output(self):
+        """Returns detailed phase information."""
+
+        _outputs = {
+            "substructure_steel_mass": self.substructure_steel_mass,
+            "substructure_steel_cost": self.substructure_steel_cost,
+            "substructure_mass": self.substructure_mass,
+            "substructure_cost": self.substructure_unit_cost,
+        }
+
+        return _outputs

--- a/tests/data/library/project/config/semisubmersible_design_custom.yaml
+++ b/tests/data/library/project/config/semisubmersible_design_custom.yaml
@@ -3,11 +3,11 @@ plant:
 site:
   depth: 500
 turbine:
-  rotor_diameter: 220
-  turbine_rating: 12
+  rotor_diameter: 240
+  turbine_rating: 15
 semisubmersible_design:
   column_diameter: 12.5
-  wall_thickness": 0.0.045
+  wall_thickness": 0.045
   column_height": 35
   pontoon_length": 51.75
   pontoon_width": 12.5

--- a/tests/data/library/project/config/semisubmersible_design_custom.yaml
+++ b/tests/data/library/project/config/semisubmersible_design_custom.yaml
@@ -1,0 +1,20 @@
+plant:
+  num_turbines: 50
+site:
+  depth: 500
+turbine:
+  rotor_diameter: 220
+  turbine_rating: 12
+semisubmersible_design:
+  column_diameter: 12.5
+  wall_thickness": 0.0.045
+  column_height": 35
+  pontoon_length": 51.75
+  pontoon_width": 12.5
+  pontoon_height": 7
+  strut_diameter": 0.9
+  steel_density": 7980
+  ballast_mass": 2540
+  tower_interface_mass": 100
+  steel_CR": 4500
+  ballast_material_CR": 150

--- a/tests/phases/design/test_semisubmersible_design.py
+++ b/tests/phases/design/test_semisubmersible_design.py
@@ -90,6 +90,10 @@ def test_calc_geometric_scale_factor():
 
     assert custom.geom_scale_factor == pytest.approx(0.9392, 1e-4)
 
+    with pytest.raises(KeyError):
+        config["turbine"]["rotor_diameter"] = None
+        custom.run()
+
 
 def test_bouyant_column_volume():
 

--- a/tests/phases/design/test_semisubmersible_design.py
+++ b/tests/phases/design/test_semisubmersible_design.py
@@ -9,7 +9,11 @@ from itertools import product
 
 import pytest
 
-from ORBIT.phases.design import SemiSubmersibleDesign
+from ORBIT.core.library import extract_library_specs
+from ORBIT.phases.design import (
+    SemiSubmersibleDesign,
+    CustomSemiSubmersibleDesign,
+)
 
 base = {
     "site": {"depth": 500},
@@ -63,5 +67,88 @@ def test_design_kwargs():
         s = SemiSubmersibleDesign(config)
         s.run()
         cost = s.total_cost
+
+        assert cost != base_cost
+
+
+config_custom = extract_library_specs(
+    "config", "semisubmersible_design_custom"
+)
+
+
+def test_calc_geometric_scale_factor():
+    pass
+
+
+def test_bouyant_column_volume():
+    pass
+
+
+def test_center_column_volume():
+    pass
+
+
+def test_pontoon_volume():
+    pass
+
+
+def test_strut_volume():
+    pass
+
+
+def test_substructure_steel_mass():
+    pass
+
+
+def test_ballast_mass():
+    pass
+
+
+def test_tower_interface_mass():
+    pass
+
+
+def test_substructure_steel_cost():
+    pass
+
+
+def test_substructure_mass():
+    pass
+
+
+def test_substructure_unit_cost():
+    pass
+
+
+def test_custom_design_kwargs():
+
+    test_kwargs = {
+        "column_diameter": 15,
+        "wall_thickness": 0.1,
+        "column_height": 20,
+        "pontoon_length": 52,
+        "pontoon_width": 15,
+        "pontoon_height": 5,
+        "strut_diameter": 1.0,
+        "steel_density": 8500,
+        "ballast_mass": 1000,
+        "tower_interface_mass": 125,
+        "steel_CR": 3000,
+        "ballast_material_CR": 200,
+    }
+
+    cust = CustomSemiSubmersibleDesign(config_custom)
+    cust.run()
+    base_cost = cust.total_cost
+
+    for k, v in test_kwargs.items():
+
+        config = deepcopy(config_custom)
+        config["semisubmersible_design"] = {}
+        config["semisubmersible_design"][k] = v
+
+        cust = CustomSemiSubmersibleDesign(config)
+        cust.run()
+        cost = cust.total_cost
 
         assert cost != base_cost

--- a/tests/phases/design/test_semisubmersible_design.py
+++ b/tests/phases/design/test_semisubmersible_design.py
@@ -77,47 +77,98 @@ config_custom = extract_library_specs(
 
 
 def test_calc_geometric_scale_factor():
-    pass
+
+    config = deepcopy(config_custom)
+
+    custom = CustomSemiSubmersibleDesign(config)
+    custom.run()
+
+    assert custom.geom_scale_factor == 1.0
+
+    config["turbine"]["rotor_diameter"] = 220
+    custom.run()
+
+    assert custom.geom_scale_factor == pytest.approx(0.9392, 1e-4)
 
 
 def test_bouyant_column_volume():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.bouyant_column_volume == pytest.approx(72.5136, 1e-4)
 
 
 def test_center_column_volume():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.center_column_volume == pytest.approx(39.4059, 1e-4)
 
 
 def test_pontoon_volume():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.pontoon_volume == pytest.approx(90.4021, 1e-4)
 
 
 def test_strut_volume():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.strut_volume == pytest.approx(32.9219, 1e-4)
 
 
 def test_substructure_steel_mass():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.substructure_steel_mass == pytest.approx(5000, 1e0)
 
 
 def test_ballast_mass():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.ballast_mass == 2540
 
 
 def test_tower_interface_mass():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.tower_interface_mass == 100
 
 
 def test_substructure_steel_cost():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.steel_cr == 4500
 
 
 def test_substructure_mass():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.substructure_mass == pytest.approx(7642, 1e0)
 
 
 def test_substructure_unit_cost():
-    pass
+
+    custom = CustomSemiSubmersibleDesign(config_custom)
+    custom.run()
+
+    assert custom.substructure_unit_cost == pytest.approx(2.3343e7, 1e-4)
 
 
 def test_custom_design_kwargs():


### PR DESCRIPTION
The existing SemiSubmersible() design module originated from a Maness et al. 2017 and used cost curves that scaled all the sub-components by turbine rating. These cost curves are undoubtedly out of date and do not account for different turbine configurations. 

The CustomSemiSubmersible() class that was added is based on the a published design of U-Maine's Volturnus design for a 15MW turbine. The model also combines U-Mass's power-law geometric scaling factor to adjust the size of the platform based on rotor diameter (from 15MW to XMW). The user can specify the roughly 12 design variables to size the platform to whatever they want. They can also set the power-law exponent to 0 if they want to avoid it altogether and pass through their own design for any given turbine. Citations included in the model.