### PR TITLE
Enhancing tests for design module's total cost

### DIFF
--- a/ORBIT/phases/design/_cables.py
+++ b/ORBIT/phases/design/_cables.py
@@ -84,7 +84,18 @@ class Cable:
             raise ValueError(f"{needs_value} must be defined in cable_specs")
 
         self.line_frequency = cable_specs.get("line_frequency", 60)
-        self.cable_type = cable_specs.get("cable_type", "HVAC")
+        cable_type = cable_specs.get("cable_type", "HVAC").split("-")
+        if len(cable_type) == 1:
+            self.cable_type = cable_type[0].upper()
+        elif len(cable_type) == 2:
+            self.cable_type = (
+                f"{cable_type[0].upper()}-{cable_type[1].lower()}"
+            )
+        else:
+            raise ValueError(
+                "`cable_type` should be of the form `type-subtype`,"
+                " e.g. 'HVDC-monopole'."
+            )
 
         # Calc additional cable specs
         if self.cable_type == "HVAC":

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -274,7 +274,7 @@ class ElectricalDesign(CableSystem):
         num_required = np.ceil(self._plant_capacity / self.cable.cable_power)
         num_redundant = self._design.get("num_redundant", 0)
 
-        if "HVDC" in self.cable.cable_type:
+        if "HVDC" in self.cable.cable_type.upper():
             num_required *= 2
             num_redundant *= 2
 
@@ -369,7 +369,7 @@ class ElectricalDesign(CableSystem):
             "substation_capacity", 1200
         )  # MW
 
-        if "HVDC" in self.cable.cable_type:
+        if "HVDC" in self.cable.cable_type.upper():
             self.num_substations = self._oss_design.get(
                 "num_substations", int(self.num_cables / 2)
             )
@@ -406,7 +406,9 @@ class ElectricalDesign(CableSystem):
         self.num_mpt = self.num_cables
 
         self.mpt_cost = (
-            0 if "HVDC" in self.cable.cable_type else self.num_mpt * _mpt_cost
+            0
+            if "HVDC" in self.cable.cable_type.upper()
+            else self.num_mpt * _mpt_cost
         )
 
         self.mpt_rating = (
@@ -426,7 +428,7 @@ class ElectricalDesign(CableSystem):
             _key, self.get_default_cost("substation_design", _key)
         )
 
-        if "HVDC" in self.cable.cable_type:
+        if "HVDC" in self.cable.cable_type.upper():
             self.compensation = 0
         else:
             for cable in self.cables.values():
@@ -445,7 +447,7 @@ class ElectricalDesign(CableSystem):
         )
 
         self.num_switchgear = (
-            0 if "HVDC" in self.cable.cable_type else self.num_cables
+            0 if "HVDC" in self.cable.cable_type.upper() else self.num_cables
         )
 
         self.switchgear_cost = self.num_switchgear * switchgear_cost
@@ -459,7 +461,7 @@ class ElectricalDesign(CableSystem):
         )
 
         num_dc_breakers = (
-            self.num_cables if "HVDC" in self.cable.cable_type else 0
+            self.num_cables if "HVDC" in self.cable.cable_type.upper() else 0
         )
 
         self.dc_breaker_cost = num_dc_breakers * dc_breaker_cost
@@ -539,7 +541,7 @@ class ElectricalDesign(CableSystem):
 
         substructure_pile_mass = (
             0
-            if "Floating" in self.substructure_type
+            if self.substructure_type.lower() == "floating"
             else 8 * substructure_mass**0.5574
         )
 

--- a/ORBIT/phases/design/electrical_export.py
+++ b/ORBIT/phases/design/electrical_export.py
@@ -140,7 +140,7 @@ class ElectricalDesign(CableSystem):
 
         self.substructure_type = self._oss_design.get(
             "oss_substructure_type", "Monopile"
-        )
+        ).title()
 
         self._outputs = {}
 
@@ -274,7 +274,7 @@ class ElectricalDesign(CableSystem):
         num_required = np.ceil(self._plant_capacity / self.cable.cable_power)
         num_redundant = self._design.get("num_redundant", 0)
 
-        if "HVDC" in self.cable.cable_type.upper():
+        if "HVDC" in self.cable.cable_type:
             num_required *= 2
             num_redundant *= 2
 
@@ -369,7 +369,7 @@ class ElectricalDesign(CableSystem):
             "substation_capacity", 1200
         )  # MW
 
-        if "HVDC" in self.cable.cable_type.upper():
+        if "HVDC" in self.cable.cable_type:
             self.num_substations = self._oss_design.get(
                 "num_substations", int(self.num_cables / 2)
             )
@@ -406,9 +406,7 @@ class ElectricalDesign(CableSystem):
         self.num_mpt = self.num_cables
 
         self.mpt_cost = (
-            0
-            if "HVDC" in self.cable.cable_type.upper()
-            else self.num_mpt * _mpt_cost
+            0 if "HVDC" in self.cable.cable_type else self.num_mpt * _mpt_cost
         )
 
         self.mpt_rating = (
@@ -428,7 +426,7 @@ class ElectricalDesign(CableSystem):
             _key, self.get_default_cost("substation_design", _key)
         )
 
-        if "HVDC" in self.cable.cable_type.upper():
+        if "HVDC" in self.cable.cable_type:
             self.compensation = 0
         else:
             for cable in self.cables.values():
@@ -447,7 +445,7 @@ class ElectricalDesign(CableSystem):
         )
 
         self.num_switchgear = (
-            0 if "HVDC" in self.cable.cable_type.upper() else self.num_cables
+            0 if "HVDC" in self.cable.cable_type else self.num_cables
         )
 
         self.switchgear_cost = self.num_switchgear * switchgear_cost
@@ -461,7 +459,7 @@ class ElectricalDesign(CableSystem):
         )
 
         num_dc_breakers = (
-            self.num_cables if "HVDC" in self.cable.cable_type.upper() else 0
+            self.num_cables if "HVDC" in self.cable.cable_type else 0
         )
 
         self.dc_breaker_cost = num_dc_breakers * dc_breaker_cost
@@ -541,7 +539,7 @@ class ElectricalDesign(CableSystem):
 
         substructure_pile_mass = (
             0
-            if self.substructure_type.lower() == "floating"
+            if self.substructure_type == "Floating"
             else 8 * substructure_mass**0.5574
         )
 

--- a/ORBIT/phases/design/mooring_system_design.py
+++ b/ORBIT/phases/design/mooring_system_design.py
@@ -73,8 +73,12 @@ class MooringSystemDesign(DesignPhase):
 
         self._design = self.config.get("mooring_system_design", {})
         self.num_lines = self._design.get("num_lines", 4)
-        self.anchor_type = self._design.get("anchor_type", "Suction Pile")
-        self.mooring_type = self._design.get("mooring_type", "Catenary")
+        self.anchor_type = self._design.get(
+            "anchor_type", "Suction Pile"
+        ).title()
+        self.mooring_type = self._design.get(
+            "mooring_type", "Catenary"
+        ).title()
 
         # Semi-Taut mooring system design parameters based on depth [2].
         self._semitaut_params = {
@@ -161,7 +165,7 @@ class MooringSystemDesign(DesignPhase):
         """
 
         # Add extra fixed line length for drag embedments
-        if any(w in self.anchor_type.lower() for w in ["drag", "embedment"]):
+        if self.anchor_type == "Drag Embedment":
             fixed = self._design.get("drag_embedment_fixed_length", 500)
 
         else:
@@ -169,7 +173,7 @@ class MooringSystemDesign(DesignPhase):
 
         draft = self._design.get("draft_depth", 20)
 
-        if "semitaut" in self.mooring_type.lower():
+        if self.mooring_type == "Semitaut":
 
             # Interpolation of rope and chain length at project depth
             self.chain_length = interp1d(
@@ -209,7 +213,7 @@ class MooringSystemDesign(DesignPhase):
                 + self.rope_length * rope_mass_per_m
             ) / 1e3  # tonnes
 
-        elif "tlp" in self.mooring_type.lower():
+        elif self.mooring_type == "Tlp":
 
             self.line_length = self.depth - draft
 
@@ -233,11 +237,9 @@ class MooringSystemDesign(DesignPhase):
         different anchors.
         """
 
-        if "semitaut" in self.mooring_type.lower():
+        if self.mooring_type == "Semitaut":
 
-            if any(
-                w in self.anchor_type.lower() for w in ["drag", "embedment"]
-            ):
+            if self.anchor_type == "Drag Embedment":
                 self.anchor_mass = 20
 
                 # Interpolation of anchor cost at project depth
@@ -255,9 +257,7 @@ class MooringSystemDesign(DesignPhase):
 
         else:
 
-            if any(
-                w in self.anchor_type.lower() for w in ["drag", "embedment"]
-            ):
+            if self.anchor_type == "Drag Embedment":
                 self.anchor_mass = 20
                 self.anchor_cost = self.breaking_load / 9.81 / 20.0 * 2000.0
 
@@ -271,7 +271,7 @@ class MooringSystemDesign(DesignPhase):
     def line_cost(self):
         """Returns cost of one line mooring line."""
 
-        if "semitaut" in self.mooring_type.lower():
+        if self.mooring_type == "Semitaut":
             # Interpolation of line cost at project depth
             line_cost = interp1d(
                 self._semitaut_params["depths"],

--- a/ORBIT/phases/design/mooring_system_design.py
+++ b/ORBIT/phases/design/mooring_system_design.py
@@ -161,7 +161,7 @@ class MooringSystemDesign(DesignPhase):
         """
 
         # Add extra fixed line length for drag embedments
-        if self.anchor_type == "Drag Embedment":
+        if any(w in self.anchor_type.lower() for w in ["drag", "embedment"]):
             fixed = self._design.get("drag_embedment_fixed_length", 500)
 
         else:
@@ -169,7 +169,7 @@ class MooringSystemDesign(DesignPhase):
 
         draft = self._design.get("draft_depth", 20)
 
-        if self.mooring_type == "SemiTaut":
+        if "semitaut" in self.mooring_type.lower():
 
             # Interpolation of rope and chain length at project depth
             self.chain_length = interp1d(
@@ -209,7 +209,7 @@ class MooringSystemDesign(DesignPhase):
                 + self.rope_length * rope_mass_per_m
             ) / 1e3  # tonnes
 
-        elif self.mooring_type == "TLP":
+        elif "tlp" in self.mooring_type.lower():
 
             self.line_length = self.depth - draft
 
@@ -233,9 +233,11 @@ class MooringSystemDesign(DesignPhase):
         different anchors.
         """
 
-        if self.mooring_type == "SemiTaut":
+        if "semitaut" in self.mooring_type.lower():
 
-            if self.anchor_type == "Drag Embedment":
+            if any(
+                w in self.anchor_type.lower() for w in ["drag", "embedment"]
+            ):
                 self.anchor_mass = 20
 
                 # Interpolation of anchor cost at project depth
@@ -253,7 +255,9 @@ class MooringSystemDesign(DesignPhase):
 
         else:
 
-            if self.anchor_type == "Drag Embedment":
+            if any(
+                w in self.anchor_type.lower() for w in ["drag", "embedment"]
+            ):
                 self.anchor_mass = 20
                 self.anchor_cost = self.breaking_load / 9.81 / 20.0 * 2000.0
 
@@ -267,7 +271,7 @@ class MooringSystemDesign(DesignPhase):
     def line_cost(self):
         """Returns cost of one line mooring line."""
 
-        if self.mooring_type == "SemiTaut":
+        if "semitaut" in self.mooring_type.lower():
             # Interpolation of line cost at project depth
             line_cost = interp1d(
                 self._semitaut_params["depths"],

--- a/tests/phases/design/test_array_system_design.py
+++ b/tests/phases/design/test_array_system_design.py
@@ -239,3 +239,11 @@ def test_floating_calculations():
 
     with_cat_length = sim3.total_length
     assert with_cat_length < no_cat_length
+
+
+def test_total_cable_cost():
+
+    array = ArraySystemDesign(config_full_ring)
+    array.run()
+
+    assert array.total_cable_cost == pytest.approx(11969999, abs=1e0)

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -267,11 +267,23 @@ def test_new_old_hvac_substation():
     assert new.shunt_reactor_cost != old.shunt_reactor_cost
 
 
+def test_hvac_substation():
+    config = deepcopy(base)
+
+    hvac = ElectricalDesign(config)
+    hvac.run()
+
+    assert hvac.total_substation_cost == pytest.approx(134448256, abs=1e0)
+
+
 def test_hvdc_substation():
     config = deepcopy(base)
     config["export_system_design"] = {"cables": "HVDC_2000mm_320kV"}
     elect = ElectricalDesign(config)
     elect.run()
+
+    assert elect.total_substation_cost == pytest.approx(451924714, abs=1e0)
+
     assert elect.converter_cost != 0
     assert elect.shunt_reactor_cost == 0
     assert elect.dc_breaker_cost != 0
@@ -285,7 +297,14 @@ def test_hvdc_substation():
     elect = ElectricalDesign(config)
     elect.run()
 
-    # assert elect.num_converters == elect.num_cables    # breaks
+    assert elect.total_substation_cost == pytest.approx(802924714, abs=1e0)
+
+    assert elect.converter_cost != 0
+    assert elect.shunt_reactor_cost == 0
+    assert elect.dc_breaker_cost != 0
+    assert elect.switchgear_cost == 0
+    assert elect.mpt_cost == 0
+    # assert elect.num_cables / elect.num_converters == 2  # breaks
 
 
 def test_onshore_substation():

--- a/tests/phases/design/test_monopile_design.py
+++ b/tests/phases/design/test_monopile_design.py
@@ -117,3 +117,14 @@ def test_transition_piece_kwargs():
         results = m._outputs["transition_piece"]
 
         assert results != base_results
+
+
+def test_total_cost():
+    """Simple unit test to track total cost of base configuration."""
+
+    mono = MonopileDesign(base)
+    mono.run()
+
+    print(mono.total_cost)
+
+    assert mono.total_cost == pytest.approx(68833066, abs=1e0)

--- a/tests/phases/design/test_mooring_system_design.py
+++ b/tests/phases/design/test_mooring_system_design.py
@@ -80,6 +80,8 @@ def test_catenary_mooring_system_kwargs():
 
     base_cost = moor.detailed_output["system_cost"]
 
+    assert base_cost == pytest.approx(76173891, abs=1e0)
+
     for k, v in test_kwargs.items():
         config = deepcopy(base)
         config["mooring_system_design"] = {}
@@ -108,6 +110,8 @@ def test_semitaut_mooring_system_kwargs():
 
     base_cost = moor.detailed_output["system_cost"]
 
+    assert base_cost == pytest.approx(102227311, abs=1e0)
+
     for k, v in test_kwargs.items():
         config = deepcopy(semi_base)
         config["mooring_system_design"] = {}
@@ -135,6 +139,8 @@ def test_tlp_mooring_system_kwargs():
     moor.run()
 
     base_cost = moor.detailed_output["system_cost"]
+
+    assert base_cost == pytest.approx(57633231, abs=1e0)
 
     for k, v in test_kwargs.items():
         config = deepcopy(tlp_base)

--- a/tests/phases/design/test_oss_design.py
+++ b/tests/phases/design/test_oss_design.py
@@ -86,3 +86,11 @@ def test_oss_kwargs():
         cost = o.total_cost
 
         assert cost != base_cost
+
+
+def test_total_cost():
+
+    oss = OffshoreSubstationDesign(base)
+    oss.run()
+
+    assert oss.total_cost == pytest.approx(158022050, abs=1e0)

--- a/tests/phases/design/test_semisubmersible_design.py
+++ b/tests/phases/design/test_semisubmersible_design.py
@@ -65,3 +65,11 @@ def test_design_kwargs():
         cost = s.total_cost
 
         assert cost != base_cost
+
+
+def test_total_cost():
+
+    semi = SemiSubmersibleDesign(base)
+    semi.run()
+
+    assert semi.total_cost == pytest.approx(630709636, abs=1e0)

--- a/tests/phases/design/test_spar_design.py
+++ b/tests/phases/design/test_spar_design.py
@@ -65,3 +65,11 @@ def test_design_kwargs():
         cost = s.total_cost
 
         assert cost != base_cost
+
+
+def test_total_cost():
+
+    spar = SparDesign(base)
+    spar.run()
+
+    assert spar.total_cost == pytest.approx(698569358, abs=1e0)

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -26,6 +26,9 @@ weather_df = pd.DataFrame(test_weather).set_index("datetime")
 
 config = extract_library_specs("config", "project_manager")
 complete_project = extract_library_specs("config", "complete_project")
+complete_floating_project = extract_library_specs(
+    "config", "complete_floating_project"
+)
 
 
 # Top Level
@@ -921,3 +924,17 @@ def test_capex_categories():
         new_breakdown["Export System Installation"]
         > baseline["Export System Installation"]
     )
+
+
+def test_total_capex():
+    """Test total capex for baseline fixed and floating project."""
+
+    fix_project = ProjectManager(complete_project)
+    fix_project.run()
+
+    assert fix_project.total_capex == pytest.approx(1207278397.56, abs=1e-1)
+
+    flt_project = ProjectManager(complete_floating_project)
+    flt_project.run()
+
+    assert flt_project.total_capex == pytest.approx(3284781912.73, abs=1e-1)


### PR DESCRIPTION
Updated several design tests to include some kind of "test_total_cost". A simple test like this should capture a snapshot of the design module's total cost for given a base case. Further, this will aid in tracking if any logic, default costs, or cost algorithms change between additions. 

Additionally, I addressed some potential if-statements matching issues in electrical_design and mooring_system_design that @rafmudaf noticed in #171. 