### PR TITLE
Reverting monopile mass assertion after load_factor was adjusted.

### DIFF
--- a/tests/phases/design/test_monopile_design.py
+++ b/tests/phases/design/test_monopile_design.py
@@ -54,7 +54,7 @@ def test_paramater_sweep(depth, mean_ws, turbine):
     assert 4 < m._outputs["monopile"]["diameter"] < 13
 
     # Check valid monopile mass
-    assert 200 < m._outputs["monopile"]["mass"] < 5000
+    assert 200 < m._outputs["monopile"]["mass"] < 2500
 
     # Check valid transition piece diameter
     assert 4 < m._outputs["transition_piece"]["diameter"] < 14


### PR DESCRIPTION
After #156 bug was fixed, the monopile volume and mass calculations were much larger than expected. That was due to a load_factor that compensated for the bug, but it did not change with the same bug fix. I changed the mass assertion from <2500 to <5000 in `test_monopile_design.py` to pass the test. 

Later, the load factor was updated in commit: d13c270b22059ed5d7651dee42e31a7484672471, but the test was not updated. 

I went back and reverted the assertion for monopile mass back < 2500 tons