### PR TITLE
Patch: Add missing permissions to PyPI actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,6 +13,8 @@ jobs:
     # Upload to PyPI on every published release
     if: github.event.action == 'published'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -14,6 +14,8 @@ jobs:
     environment: release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds the missing permissions configurations to the Test PyPI and PyPI publishing GitHub Actions.