### PR TITLE
Fix wisdem api

### DIFF
--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -43,27 +43,27 @@ class Orbit(om.Group):
         self.set_input_defaults("takt_time", 170.0, units="h")
         self.set_input_defaults("port_cost_per_month", 2e6, units="USD/mo")
         self.set_input_defaults(
-            "construction_insurance_per_kW",
+            "construction_insurance",
             34.6,
             units="USD/kW"
         )
         self.set_input_defaults(
-            "construction_financing_per_kW",
+            "construction_financing",
             218.8,
             units="USD/kW"
         )
         self.set_input_defaults(
-            "procurement_contingency_per_kW",
+            "procurement_contingency",
             154.5,
             units="USD/kW"
         )
         self.set_input_defaults(
-            "installation_contingency_per_kW",
+            "installation_contingency",
             111.8,
             units="USD/kW"
         )
-        self.set_input_defaults("commissioning_per_kW", 34.6, units="USD/kW")
-        self.set_input_defaults("decommissioning_per_kW", 56.7, units="USD/kW")
+        self.set_input_defaults("commissioning", 34.6, units="USD/kW")
+        self.set_input_defaults("decommissioning", 56.7, units="USD/kW")
         self.set_input_defaults("site_auction_price", 100e6, units="USD")
         self.set_input_defaults("site_assessment_cost", 50e6, units="USD")
         self.set_input_defaults("construction_plan_cost", 1e6, units="USD")
@@ -419,37 +419,37 @@ class OrbitWisdem(om.ExplicitComponent):
 
         # Project (based on 600GW fixed bottom farm)
         self.add_input(
-            "construction_insurance_per_kW",
+            "construction_insurance",
             34.6,
             units="USD/kW",
             desc="Cost for construction insurance",
         )
         self.add_input(
-            "construction_financing_per_kW",
+            "construction_financing",
             218.9,
             units="USD/kW",
             desc="Cost for construction financing",
         )
         self.add_input(
-            "procurement_contingency_per_kW",
+            "procurement_contingency",
             154.5,
             units="USD/kW",
             desc="Cost of procurement contingency",
         )
         self.add_input(
-            "installation_contingency_per_kW",
+            "installation_contingency",
             111.8,
             units="USD/kW",
             desc="Cost of installation contingency",
         )
         self.add_input(
-            "commissioning_per_kW",
+            "commissioning",
             34.6,
             units="USD/kW",
             desc="Commissioning cost."
         )
         self.add_input(
-            "decommissioning_per_kW",
+            "decommissioning",
             56.7, units="USD/kW",
             desc="Decommissioning cost."
         )
@@ -619,15 +619,15 @@ class OrbitWisdem(om.ExplicitComponent):
             # Project development costs
             "project_parameters": {
                 "construction_insurance":
-                    float(inputs["construction_insurance_per_kW"][0]),
+                    float(inputs["construction_insurance"][0]),
                 "construction_financing":
-                    float(inputs["construction_financing_per_kW"][0]),
+                    float(inputs["construction_financing"][0]),
                 "procurement_contigency":
-                    float(inputs["procurement_contingency_per_kW"][0]),
+                    float(inputs["procurement_contingency"][0]),
                 "installation_contigency":
-                    float(inputs["installation_contingency_per_kW"][0]),
-                "commissioning": float(inputs["commissioning_per_kW"][0]),
-                "decommissioning": float(inputs["decommissioning_per_kW"][0]),
+                    float(inputs["installation_contingency"][0]),
+                "commissioning": float(inputs["commissioning"][0]),
+                "decommissioning": float(inputs["decommissioning"][0]),
                 "site_auction_price": float(inputs["site_auction_price"][0]),
                 "site_assessment_cost":
                     float(inputs["site_assessment_cost"][0]),

--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -810,6 +810,8 @@ class OrbitWisdem(om.ExplicitComponent):
         project = ProjectManager(config)
         project.run()
 
+        # The ORBIT version of total_capex includes turbine capex, so we do our own sum of
+        # the parts here that wisdem doesn't account for
         capacity_kW = 1e3 * inputs["turbine_rating"] * discrete_inputs["number_of_turbines"]
         outputs["bos_capex"] = project.bos_capex
         outputs["soft_capex"] = project.soft_capex

--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -42,28 +42,14 @@ class Orbit(om.Group):
         self.set_input_defaults("num_assembly_lines", 1)
         self.set_input_defaults("takt_time", 170.0, units="h")
         self.set_input_defaults("port_cost_per_month", 2e6, units="USD/mo")
-        self.set_input_defaults(
-            "construction_insurance",
-            34.6,
-            units="USD/kW"
-        )
-        self.set_input_defaults(
-            "construction_financing",
-            218.8,
-            units="USD/kW"
-        )
-        self.set_input_defaults(
-            "procurement_contingency",
-            154.5,
-            units="USD/kW"
-        )
-        self.set_input_defaults(
-            "installation_contingency",
-            111.8,
-            units="USD/kW"
-        )
-        self.set_input_defaults("commissioning", 34.6, units="USD/kW")
-        self.set_input_defaults("decommissioning", 56.7, units="USD/kW")
+        self.set_input_defaults("construction_insurance_factor", 0.0115)
+        self.set_input_defaults("construction_financing_factor", 1.0695)
+        self.set_input_defaults("procurement_contingency_factor", 0.0575)
+        self.set_input_defaults("installation_contingency_factor", 0.345)
+        self.set_input_defaults("commissioning_factor", 0.0115)
+        self.set_input_defaults("decommissioning_factor", 0.1725)
+        self.set_input_defaults("tax_rate", 0.26)
+        self.set_input_defaults("interest_during_construction",0.044)
         self.set_input_defaults("site_auction_price", 100e6, units="USD")
         self.set_input_defaults("site_assessment_cost", 50e6, units="USD")
         self.set_input_defaults("construction_plan_cost", 1e6, units="USD")
@@ -419,39 +405,44 @@ class OrbitWisdem(om.ExplicitComponent):
 
         # Project (based on 600GW fixed bottom farm)
         self.add_input(
-            "construction_insurance",
-            34.6,
-            units="USD/kW",
-            desc="Cost for construction insurance",
+            "construction_insurance_factor",
+            0.0115,
+            desc="Factor for construction insurance. (0.0-0.1)",
         )
         self.add_input(
-            "construction_financing",
-            218.9,
-            units="USD/kW",
-            desc="Cost for construction financing",
+            "construction_financing_factor",
+            1.0695,
+            desc="Financing factor applied during construction phase.(0.0-inf)"
         )
         self.add_input(
-            "procurement_contingency",
-            154.5,
-            units="USD/kW",
-            desc="Cost of procurement contingency",
+            "procurement_contingency_factor",
+            0.0575,
+            desc="Factor for procurement contingency. (0.0-1.0)",
         )
         self.add_input(
-            "installation_contingency",
-            111.8,
-            units="USD/kW",
-            desc="Cost of installation contingency",
+            "installation_contingency_factor",
+            0.345,
+            desc="Factor for installation contingency. (0.0-0.1)",
         )
         self.add_input(
-            "commissioning",
-            34.6,
-            units="USD/kW",
-            desc="Commissioning cost."
+            "commissioning_factor",
+            0.0115,
+            desc="Factor for commissioning cost. (0.0-inf)"
         )
         self.add_input(
-            "decommissioning",
-            56.7, units="USD/kW",
-            desc="Decommissioning cost."
+            "decommissioning_factor",
+            0.1725,
+            desc="Factor for decommissioning cost. (0.0-inf)"
+        )
+        self.add_input(
+            "tax_rate",
+            0.26,
+            desc="Tax rate. (0.0-1.0)",
+        )
+        self.add_input(
+            "interest_during_construction",
+            0.044,
+            desc="Interest rate for financing. (0.0-1.0)"
         )
         self.add_input(
             "site_auction_price",
@@ -618,16 +609,21 @@ class OrbitWisdem(om.ExplicitComponent):
             },
             # Project development costs
             "project_parameters": {
-                "construction_insurance":
-                    float(inputs["construction_insurance"][0]),
-                "construction_financing":
-                    float(inputs["construction_financing"][0]),
-                "procurement_contigency":
-                    float(inputs["procurement_contingency"][0]),
-                "installation_contigency":
-                    float(inputs["installation_contingency"][0]),
-                "commissioning": float(inputs["commissioning"][0]),
-                "decommissioning": float(inputs["decommissioning"][0]),
+                "construction_insurance_factor":
+                    float(inputs["construction_insurance_factor"][0]),
+                "construction_financing_factor":
+                    float(inputs["construction_financing_factor"][0]),
+                "procurement_contigency_factor":
+                    float(inputs["procurement_contingency_factor"][0]),
+                "installation_contigency_factor":
+                    float(inputs["installation_contingency_factor"][0]),
+                "commissioning_factor":
+                    float(inputs["commissioning_factor"][0]),
+                "decommissioning_factor":
+                    float(inputs["decommissioning_factor"][0]),
+                "tax_rate": float(inputs["tax_rate"][0]),
+                "interest_during_construction":
+                    float(inputs["interest_during_construction"][0]),
                 "site_auction_price": float(inputs["site_auction_price"][0]),
                 "site_assessment_cost":
                     float(inputs["site_assessment_cost"][0]),

--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -484,22 +484,33 @@ class OrbitWisdem(om.ExplicitComponent):
             "bos_capex",
             0.0,
             units="USD",
-            desc="Total BOS CAPEX not including commissioning or"
-             " decommissioning.",
+            desc="Sum of system and installation capex",
+        )
+        self.add_output(
+            "soft_capex",
+            0.0,
+            units="USD",
+            desc="Project costs associated with commissioning, decommissioning and financing",
+        )
+        self.add_output(
+            "project_capex",
+            0.0,
+            units="USD",
+            desc="costs associated with the lease area, "+
+            "the development of the construction operations plan,"+
+            "and any environmental review and other upfront project costs."
         )
         self.add_output(
             "total_capex",
             0.0,
             units="USD",
-            desc="Total BOS CAPEX including commissioning and"
-            " decommissioning.",
+            desc="Total capex of bos + soft + project",
         )
         self.add_output(
             "total_capex_kW",
             0.0,
             units="USD/kW",
-            desc="Total BOS CAPEX including commissioning and"
-            " decommissioning.",
+            desc="Total capex of bos + soft + project per rated project capacity in kW",
         )
         self.add_output(
             "installation_time",
@@ -799,8 +810,11 @@ class OrbitWisdem(om.ExplicitComponent):
         project = ProjectManager(config)
         project.run()
 
+        capacity_kW = 1e3 * inputs["turbine_rating"] * discrete_inputs["number_of_turbines"]
         outputs["bos_capex"] = project.bos_capex
-        outputs["total_capex"] = project.total_capex
-        outputs["total_capex_kW"] = project.total_capex_per_kw
+        outputs["soft_capex"] = project.soft_capex
+        outputs["project_capex"] = project.project_capex
+        outputs["total_capex"] = project.bos_capex + project.soft_capex + project.project_capex
+        outputs["total_capex_kW"] = outputs["total_capex"] / capacity_kW
         outputs["installation_time"] = project.installation_time
         outputs["installation_capex"] = project.installation_capex

--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -42,11 +42,28 @@ class Orbit(om.Group):
         self.set_input_defaults("num_assembly_lines", 1)
         self.set_input_defaults("takt_time", 170.0, units="h")
         self.set_input_defaults("port_cost_per_month", 2e6, units="USD/mo")
-        self.set_input_defaults("construction_insurance", 44.0, units="USD/kW")
-        self.set_input_defaults("construction_financing", 183.0, units="USD/kW")
-        self.set_input_defaults("contingency", 316.0, units="USD/kW")
-        self.set_input_defaults("commissioning_cost_kW", 44.0, units="USD/kW")
-        self.set_input_defaults("decommissioning_cost_kW", 58.0, units="USD/kW")
+        self.set_input_defaults(
+            "construction_insurance_per_kW",
+            34.6,
+            units="USD/kW"
+        )
+        self.set_input_defaults(
+            "construction_financing_per_kW",
+            218.8,
+            units="USD/kW"
+        )
+        self.set_input_defaults(
+            "procurement_contingency_per_kW",
+            154.5,
+            units="USD/kW"
+        )
+        self.set_input_defaults(
+            "installation_contingency_per_kW",
+            111.8,
+            units="USD/kW"
+        )
+        self.set_input_defaults("commissioning_per_kW", 34.6, units="USD/kW")
+        self.set_input_defaults("decommissioning_per_kW", 56.7, units="USD/kW")
         self.set_input_defaults("site_auction_price", 100e6, units="USD")
         self.set_input_defaults("site_assessment_cost", 50e6, units="USD")
         self.set_input_defaults("construction_plan_cost", 1e6, units="USD")
@@ -116,14 +133,15 @@ class OrbitWisdem(om.ExplicitComponent):
             "num_station_keeping",
             3,
             desc=(
-                "Number of station keeping or AHTS vessels that attach to floating"
-                " platforms under tow-out."
+                "Number of station keeping or AHTS vessels that attach to"
+                " floating platforms under tow-out."
             ),
         )
         self.add_discrete_input(
             "oss_install_vessel",
             "example_heavy_lift_vessel",
-            desc="Vessel configuration to use for installation of offshore substations.",  # noqa: E501
+            desc="Vessel configuration to use for installation"
+             " of offshore substations.",
         )
 
         # Site
@@ -305,12 +323,14 @@ class OrbitWisdem(om.ExplicitComponent):
             "takt_time",
             170.0,
             units="h",
-            desc="Substructure assembly cycle time when doing assembly at the port.",  # noqa: E501
+            desc="Substructure assembly cycle time when doing assembly at the"
+                " port.",
         )
         self.add_discrete_input(
             "num_assembly_lines",
             1,
-            desc="Number of assembly lines used when assembly occurs at the port.",  # noqa: E501
+            desc="Number of assembly lines used when assembly occurs at the"
+                " port.",
         )
         self.add_discrete_input(
             "num_port_cranes",
@@ -397,24 +417,41 @@ class OrbitWisdem(om.ExplicitComponent):
             desc="Transition piece unit cost.",
         )
 
-        # Project
+        # Project (based on 600GW fixed bottom farm)
         self.add_input(
-            "construction_insurance",
-            44.0,
+            "construction_insurance_per_kW",
+            34.6,
             units="USD/kW",
             desc="Cost for construction insurance",
         )
         self.add_input(
-            "construction_financing",
-            183.0,
+            "construction_financing_per_kW",
+            218.9,
             units="USD/kW",
             desc="Cost for construction financing",
         )
         self.add_input(
-            "contingency",
-            316.0,
+            "procurement_contingency_per_kW",
+            154.5,
             units="USD/kW",
-            desc="Cost in case of contingency",
+            desc="Cost of procurement contingency",
+        )
+        self.add_input(
+            "installation_contingency_per_kW",
+            111.8,
+            units="USD/kW",
+            desc="Cost of installation contingency",
+        )
+        self.add_input(
+            "commissioning_per_kW",
+            34.6,
+            units="USD/kW",
+            desc="Commissioning cost."
+        )
+        self.add_input(
+            "decommissioning_per_kW",
+            56.7, units="USD/kW",
+            desc="Decommissioning cost."
         )
         self.add_input(
             "site_auction_price",
@@ -449,8 +486,6 @@ class OrbitWisdem(om.ExplicitComponent):
                 " of Ocean Energy Management (BOEM)"
             ),
         )
-        self.add_input("commissioning_cost_kW", 44.0, units="USD/kW", desc="Commissioning cost.")
-        self.add_input("decommissioning_cost_kW", 58.0, units="USD/kW", desc="Decommissioning cost.")
 
         # Outputs
         # Totals
@@ -458,19 +493,22 @@ class OrbitWisdem(om.ExplicitComponent):
             "bos_capex",
             0.0,
             units="USD",
-            desc="Total BOS CAPEX not including commissioning or decommissioning.",  # noqa: E501
+            desc="Total BOS CAPEX not including commissioning or"
+             " decommissioning.",
         )
         self.add_output(
             "total_capex",
             0.0,
             units="USD",
-            desc="Total BOS CAPEX including commissioning and decommissioning.",  # noqa: E501
+            desc="Total BOS CAPEX including commissioning and"
+            " decommissioning.",
         )
         self.add_output(
             "total_capex_kW",
             0.0,
             units="USD/kW",
-            desc="Total BOS CAPEX including commissioning and decommissioning.",  # noqa: E501
+            desc="Total BOS CAPEX including commissioning and"
+            " decommissioning.",
         )
         self.add_output(
             "installation_time",
@@ -580,16 +618,24 @@ class OrbitWisdem(om.ExplicitComponent):
             },
             # Project development costs
             "project_parameters": {
-                "construction_insurance": float(inputs["construction_insurance"][0]),
-                "construction_financing": float(inputs["construction_financing"][0]),
-                "contingency": float(inputs["contingency"][0]),
+                "construction_insurance":
+                    float(inputs["construction_insurance_per_kW"][0]),
+                "construction_financing":
+                    float(inputs["construction_financing_per_kW"][0]),
+                "procurement_contigency":
+                    float(inputs["procurement_contingency_per_kW"][0]),
+                "installation_contigency":
+                    float(inputs["installation_contingency_per_kW"][0]),
+                "commissioning": float(inputs["commissioning_per_kW"][0]),
+                "decommissioning": float(inputs["decommissioning_per_kW"][0]),
                 "site_auction_price": float(inputs["site_auction_price"][0]),
-                "site_assessment_cost": float(inputs["site_assessment_cost"][0]),
-                "construction_plan_cost": float(inputs["construction_plan_cost"][0]),
-                "installation_plan_cost": float(inputs["installation_plan_cost"][0]),
+                "site_assessment_cost":
+                    float(inputs["site_assessment_cost"][0]),
+                "construction_plan_cost":
+                    float(inputs["construction_plan_cost"][0]),
+                "installation_plan_cost":
+                    float(inputs["installation_plan_cost"][0]),
                 "boem_review_cost": float(inputs["boem_review_cost"][0]),
-                "commissioning": float(inputs["commissioning_cost_kW"][0]),
-                "decommissioning": float(inputs["decommissioning_cost_kW"][0]),
                 "turbine_capex": float(inputs["turbine_capex"][0]),
             },
             # Phases
@@ -606,7 +652,9 @@ class OrbitWisdem(om.ExplicitComponent):
             ],
         }
 
-        if "landfall" in config and "interconnection_distance" in config["landfall"]:
+        if "landfall" in config and ("interconnection_distance"
+                in config["landfall"]
+        ):
             warn(
                 "landfall dictionary will be deprecated and moved"
                 " into [export_system_design][landfall].",
@@ -614,7 +662,9 @@ class OrbitWisdem(om.ExplicitComponent):
                 stacklevel=2,
             )
 
-        if "export_system_design" in config and "interconnection_distance" in config["export_system_design"]:
+        if "export_system_design" in config and ("interconnection_distance"
+                in config["export_system_design"]
+        ):
             warn(
                 "[export_system][interconnection_distance] will be deprecated"
                 " and moved to"

--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -42,15 +42,15 @@ class Orbit(om.Group):
         self.set_input_defaults("num_assembly_lines", 1)
         self.set_input_defaults("takt_time", 170.0, units="h")
         self.set_input_defaults("port_cost_per_month", 2e6, units="USD/mo")
-        self.set_input_defaults("commissioning_pct", 0.01)
-        self.set_input_defaults("decommissioning_pct", 0.15)
+        self.set_input_defaults("construction_insurance", 44.0, units="USD/kW")
+        self.set_input_defaults("construction_financing", 183.0, units="USD/kW")
+        self.set_input_defaults("contingency", 316.0, units="USD/kW")
+        self.set_input_defaults("commissioning_cost_kW", 44.0, units="USD/kW")
+        self.set_input_defaults("decommissioning_cost_kW", 58.0, units="USD/kW")
         self.set_input_defaults("site_auction_price", 100e6, units="USD")
-        self.set_input_defaults("site_assessment_plan_cost", 1e6, units="USD")
-        self.set_input_defaults("site_assessment_cost", 25e6, units="USD")
-        self.set_input_defaults(
-            "construction_operations_plan_cost", 2.5e6, units="USD",
-        )
-        self.set_input_defaults("design_install_plan_cost", 2.5e6, units="USD")
+        self.set_input_defaults("site_assessment_cost", 50e6, units="USD")
+        self.set_input_defaults("construction_plan_cost", 1e6, units="USD")
+        self.set_input_defaults("installation_plan_cost", 2.5e5, units="USD")
         self.set_input_defaults("boem_review_cost", 0.0, units="USD")
 
         self.add_subsystem(
@@ -116,14 +116,9 @@ class OrbitWisdem(om.ExplicitComponent):
             "num_station_keeping",
             3,
             desc=(
-                "Number of station keeping vessels that attach to floating"
+                "Number of station keeping or AHTS vessels that attach to floating"
                 " platforms under tow-out."
             ),
-        )
-        self.add_discrete_input(
-            "ahts_vessels",
-            1,
-            desc="Number of ahts vessels that attach to floating platforms under tow-out.",  # noqa: E501
         )
         self.add_discrete_input(
             "oss_install_vessel",
@@ -404,26 +399,44 @@ class OrbitWisdem(om.ExplicitComponent):
 
         # Project
         self.add_input(
+            "construction_insurance",
+            44.0,
+            units="USD/kW",
+            desc="Cost for construction insurance",
+        )
+        self.add_input(
+            "construction_financing",
+            183.0,
+            units="USD/kW",
+            desc="Cost for construction financing",
+        )
+        self.add_input(
+            "contingency",
+            316.0,
+            units="USD/kW",
+            desc="Cost in case of contingency",
+        )
+        self.add_input(
             "site_auction_price",
             100e6,
             units="USD",
             desc="Cost to secure site lease",
         )
         self.add_input(
-            "site_assessment_plan_cost",
-            1e6,
-            units="USD",
-            desc="Cost to do engineering plan for site assessment",
-        )
-        self.add_input(
             "site_assessment_cost",
-            25e6,
+            50e6,
             units="USD",
             desc="Cost to execute site assessment",
         )
         self.add_input(
-            "construction_operations_plan_cost",
-            2.5e6,
+            "construction_plan_cost",
+            1e6,
+            units="USD",
+            desc="Cost to do construction planning",
+        )
+        self.add_input(
+            "installation_plan_cost",
+            2.5e5,
             units="USD",
             desc="Cost to do construction planning",
         )
@@ -436,20 +449,8 @@ class OrbitWisdem(om.ExplicitComponent):
                 " of Ocean Energy Management (BOEM)"
             ),
         )
-        self.add_input(
-            "design_install_plan_cost",
-            2.5e6,
-            units="USD",
-            desc="Cost to do installation planning",
-        )
-
-        # Other
-        self.add_input(
-            "commissioning_pct", 0.01, desc="Commissioning percent.",
-        )
-        self.add_input(
-            "decommissioning_pct", 0.15, desc="Decommissioning percent.",
-        )
+        self.add_input("commissioning_cost_kW", 44.0, units="USD/kW", desc="Commissioning cost.")
+        self.add_input("decommissioning_cost_kW", 58.0, units="USD/kW", desc="Decommissioning cost.")
 
         # Outputs
         # Totals
@@ -505,57 +506,52 @@ class OrbitWisdem(om.ExplicitComponent):
             "export_cable_bury_vessel": "example_cable_lay_vessel",
             # Site/plant
             "site": {
-                "depth": float(inputs["site_depth"]),
-                "distance": float(inputs["site_distance"]),
+                "depth": float(inputs["site_depth"][0]),
+                "distance": float(inputs["site_distance"][0]),
                 "distance_to_landfall": float(
-                    inputs["site_distance_to_landfall"]
+                    inputs["site_distance_to_landfall"][0]
                 ),
-                "mean_windspeed": float(inputs["site_mean_windspeed"]),
-            },
-            "landfall": {
-                "interconnection_distance": float(
-                    inputs["interconnection_distance"],
-                ),
+                "mean_windspeed": float(inputs["site_mean_windspeed"][0]),
             },
             "plant": {
                 "layout": "grid",
                 "num_turbines": int(discrete_inputs["number_of_turbines"]),
-                "row_spacing": float(inputs["plant_row_spacing"]),
-                "turbine_spacing": float(inputs["plant_turbine_spacing"]),
+                "row_spacing": float(inputs["plant_row_spacing"][0]),
+                "turbine_spacing": float(inputs["plant_turbine_spacing"][0]),
                 "substation_distance": float(
-                    inputs["plant_substation_distance"]
+                    inputs["plant_substation_distance"][0]
                 ),
             },
             # Turbine + components
             "turbine": {
-                "hub_height": float(inputs["hub_height"]),
-                "rotor_diameter": float(inputs["turbine_rotor_diameter"]),
-                "turbine_rating": float(inputs["turbine_rating"]),
-                "rated_windspeed": float(inputs["turbine_rated_windspeed"]),
+                "hub_height": float(inputs["hub_height"][0]),
+                "rotor_diameter": float(inputs["turbine_rotor_diameter"][0]),
+                "turbine_rating": float(inputs["turbine_rating"][0]),
+                "rated_windspeed": float(inputs["turbine_rated_windspeed"][0]),
                 "tower": {
                     "type": "Tower",
-                    "deck_space": float(inputs["tower_deck_space"]),
-                    "mass": float(inputs["tower_mass"]),
-                    "length": float(inputs["tower_length"]),
+                    "deck_space": float(inputs["tower_deck_space"][0]),
+                    "mass": float(inputs["tower_mass"][0]),
+                    "length": float(inputs["tower_length"][0]),
                 },
                 "nacelle": {
                     "type": "Nacelle",
-                    "deck_space": float(inputs["nacelle_deck_space"]),
-                    "mass": float(inputs["nacelle_mass"]),
+                    "deck_space": float(inputs["nacelle_deck_space"][0]),
+                    "mass": float(inputs["nacelle_mass"][0]),
                 },
                 "blade": {
                     "type": "Blade",
                     "number": int(discrete_inputs["number_of_blades"]),
-                    "deck_space": float(inputs["blade_deck_space"]),
-                    "mass": float(inputs["blade_mass"]),
+                    "deck_space": float(inputs["blade_deck_space"][0]),
+                    "mass": float(inputs["blade_mass"][0]),
                 },
             },
             # Substructure components
             "transition_piece": {
                 "type": "Transition Piece",
-                "deck_space": float(inputs["transition_piece_deck_space"]),
-                "mass": float(inputs["transition_piece_mass"]),
-                "unit_cost": float(inputs["transition_piece_cost"]),
+                "deck_space": float(inputs["transition_piece_deck_space"][0]),
+                "mass": float(inputs["transition_piece_mass"][0]),
+                "unit_cost": float(inputs["transition_piece_cost"][0]),
             },
             # Electrical
             "array_system_design": {
@@ -563,10 +559,12 @@ class OrbitWisdem(om.ExplicitComponent):
             },
             "export_system_design": {
                 "cables": "XLPE_1000mm_220kV",
-                "interconnection_distance": float(
-                    inputs["interconnection_distance"]
-                ),
                 "percent_added_length": 0.1,
+                "landfall": {
+                    "interconnection_distance": float(
+                        inputs["interconnection_distance"][0],
+                    ),
+                },
             },
             # Phase Specific
             "OffshoreSubstationInstallation": {
@@ -582,25 +580,17 @@ class OrbitWisdem(om.ExplicitComponent):
             },
             # Project development costs
             "project_parameters": {
-                "site_auction_price": float(
-                    inputs["site_auction_price"]
-                ),  # 100e6,
-                "site_assessment_plan_cost": float(
-                    inputs["site_assessment_plan_cost"]
-                ),  # 1e6,
-                "site_assessment_cost": float(
-                    inputs["site_assessment_cost"]
-                ),  # 25e6,
-                "construction_operations_plan_cost": float(
-                    inputs["construction_operations_plan_cost"]
-                ),  # 2.5e6,
-                "boem_review_cost": float(inputs["boem_review_cost"]),  # 0,
-                "design_install_plan_cost": float(
-                    inputs["design_install_plan_cost"]
-                ),  # 2.5e6
-                "commissioning": float(inputs["commissioning_pct"]),
-                "decomissioning": float(inputs["decommissioning_pct"]),
-                "turbine_capex": float(inputs["turbine_capex"]),
+                "construction_insurance": float(inputs["construction_insurance"][0]),
+                "construction_financing": float(inputs["construction_financing"][0]),
+                "contingency": float(inputs["contingency"][0]),
+                "site_auction_price": float(inputs["site_auction_price"][0]),
+                "site_assessment_cost": float(inputs["site_assessment_cost"][0]),
+                "construction_plan_cost": float(inputs["construction_plan_cost"][0]),
+                "installation_plan_cost": float(inputs["installation_plan_cost"][0]),
+                "boem_review_cost": float(inputs["boem_review_cost"][0]),
+                "commissioning": float(inputs["commissioning_cost_kW"][0]),
+                "decommissioning": float(inputs["decommissioning_cost_kW"][0]),
+                "turbine_capex": float(inputs["turbine_capex"][0]),
             },
             # Phases
             # Putting monopile or semisub here would override the inputs
@@ -616,7 +606,7 @@ class OrbitWisdem(om.ExplicitComponent):
             ],
         }
 
-        if config["landfall"]["interconnection_distance"]:
+        if "landfall" in config and "interconnection_distance" in config["landfall"]:
             warn(
                 "landfall dictionary will be deprecated and moved"
                 " into [export_system_design][landfall].",
@@ -624,7 +614,7 @@ class OrbitWisdem(om.ExplicitComponent):
                 stacklevel=2,
             )
 
-        if config["export_system_design"]["interconnection_distance"]:
+        if "export_system_design" in config and "interconnection_distance" in config["export_system_design"]:
             warn(
                 "[export_system][interconnection_distance] will be deprecated"
                 " and moved to"
@@ -665,16 +655,14 @@ class OrbitWisdem(om.ExplicitComponent):
         # Unique vessels
         if floating_flag:
             vessels = {
-                "support_vessel": "example_support_vessel",
                 "ahts_vessel": "example_ahts_vessel",
                 "towing_vessel": "example_towing_vessel",
                 "mooring_install_vessel": "example_support_vessel",
                 "towing_vessel_groups": {
                     "towing_vessels": int(discrete_inputs["num_towing"]),
-                    "station_keeping_vessels": int(
+                    "ahts_vessels": int(
                         discrete_inputs["num_station_keeping"]
                     ),
-                    "ahts_vessels": int(discrete_inputs["ahts_vessels"]),
                 },
             }
         else:
@@ -694,13 +682,13 @@ class OrbitWisdem(om.ExplicitComponent):
                 "turbine_assembly_cranes": int(
                     discrete_inputs["num_port_cranes"]
                 ),
-                "monthly_rate": float(inputs["port_cost_per_month"]),
+                "monthly_rate": float(inputs["port_cost_per_month"][0]),
             }
 
             config["substructure"] = {
-                "takt_time": float(inputs["takt_time"]),
-                "unit_cost": float(inputs["floating_substructure_cost"]),
-                "towing_speed": 6,  # km/h
+                "takt_time": float(inputs["takt_time"][0]),
+                "unit_cost": float(inputs["floating_substructure_cost"][0]),
+                "towing_speed": 6.0,  # km/h
             }
 
             anchorstr_in = discrete_inputs["anchor_type"].lower()
@@ -711,18 +699,18 @@ class OrbitWisdem(om.ExplicitComponent):
 
             config["mooring_system"] = {
                 "num_lines": int(discrete_inputs["num_mooring_lines"]),
-                "line_mass": 1e-3 * float(inputs["mooring_line_mass"]),
-                "line_diam": float(inputs["mooring_line_diameter"]),
-                "line_length": float(inputs["mooring_line_length"]),
-                "line_cost": float(inputs["mooring_line_cost"]),
-                "anchor_mass": 1e-3 * float(inputs["anchor_mass"]),
+                "line_mass": 1e-3 * float(inputs["mooring_line_mass"][0]),
+                "line_diam": float(inputs["mooring_line_diameter"][0]),
+                "line_length": float(inputs["mooring_line_length"][0]),
+                "line_cost": float(inputs["mooring_line_cost"][0]),
+                "anchor_mass": 1e-3 * float(inputs["anchor_mass"][0]),
                 "anchor_type": anchorstr,
-                "anchor_cost": float(inputs["mooring_anchor_cost"]),
+                "anchor_cost": float(inputs["mooring_anchor_cost"][0]),
             }
         else:
             config["port"] = {
                 "num_cranes": int(discrete_inputs["num_port_cranes"]),
-                "monthly_rate": float(inputs["port_cost_per_month"]),
+                "monthly_rate": float(inputs["port_cost_per_month"][0]),
             }
 
             config["scour_protection_design"] = {
@@ -732,24 +720,24 @@ class OrbitWisdem(om.ExplicitComponent):
             if jacket_flag:
                 config["jacket"] = {
                     "type": "Jacket",
-                    "height": float(inputs["jacket_length"]),
+                    "height": float(inputs["jacket_length"][0]),
                     "num_legs": int(self.options["jacket_legs"]),
-                    "deck_space": 4 * float(inputs["jacket_r_foot"]) ** 2,
-                    "mass": float(inputs["jacket_mass"]),
-                    "unit_cost": float(inputs["jacket_cost"]),
+                    "deck_space": 4 * float(inputs["jacket_r_foot"][0]) ** 2,
+                    "mass": float(inputs["jacket_mass"][0]),
+                    "unit_cost": float(inputs["jacket_cost"][0]),
                 }
             else:
                 config["monopile"] = {
                     "type": "Monopile",
-                    "length": float(inputs["monopile_length"]),
-                    "diameter": float(inputs["monopile_diameter"]),
+                    "length": float(inputs["monopile_length"][0]),
+                    "diameter": float(inputs["monopile_diameter"][0]),
                     "deck_space": 0.25
                     * float(
-                        inputs["monopile_diameter"]
-                        * inputs["monopile_length"]
+                        inputs["monopile_diameter"][0]
+                        * inputs["monopile_length"][0]
                     ),
-                    "mass": float(inputs["monopile_mass"]),
-                    "unit_cost": float(inputs["monopile_cost"]),
+                    "mass": float(inputs["monopile_mass"][0]),
+                    "unit_cost": float(inputs["monopile_cost"][0]),
                 }
 
         self._orbit_config = config

--- a/ORBIT/api/wisdem.py
+++ b/ORBIT/api/wisdem.py
@@ -581,7 +581,7 @@ class OrbitWisdem(om.ExplicitComponent):
                 "num_feeders": int(discrete_inputs["num_feeders"]),
             },
             # Project development costs
-            "project_development": {
+            "project_parameters": {
                 "site_auction_price": float(
                     inputs["site_auction_price"]
                 ),  # 100e6,
@@ -598,11 +598,10 @@ class OrbitWisdem(om.ExplicitComponent):
                 "design_install_plan_cost": float(
                     inputs["design_install_plan_cost"]
                 ),  # 2.5e6
+                "commissioning": float(inputs["commissioning_pct"]),
+                "decomissioning": float(inputs["decommissioning_pct"]),
+                "turbine_capex": float(inputs["turbine_capex"]),
             },
-            # Other
-            "commissioning": float(inputs["commissioning_pct"]),
-            "decomissioning": float(inputs["decommissioning_pct"]),
-            "turbine_capex": float(inputs["turbine_capex"]),
             # Phases
             # Putting monopile or semisub here would override the inputs
             # we assume to get from WISDEM

--- a/examples/configs/example_fixed_project.yaml
+++ b/examples/configs/example_fixed_project.yaml
@@ -13,7 +13,7 @@ plant:
 landfall:
   interconnection_distance: 3
   trench_length: 2
-turbine: SWT_6MW_154m_110m
+turbine: 12MW_generic
 # Vessels
 array_cable_install_vessel: example_cable_lay_vessel
 export_cable_install_vessel: example_cable_lay_vessel
@@ -52,5 +52,3 @@ install_phases:
 # Project Inputs
 project_parameters:
   turbine_capex: 1500
-  commissioning: 0.01
-  decommissioning: 0.15

--- a/examples/configs/example_floating_project.yaml
+++ b/examples/configs/example_floating_project.yaml
@@ -57,3 +57,5 @@ install_phases:
   TurbineInstallation: 0
 # Project Inputs
 turbine: 12MW_generic
+project_parameters:
+  turbine_capex: 1500


### PR DESCRIPTION
The WISDEM API became out of sync with the changes in the recent ORBIT release, which was flagged by users.  To do a better job catching this next time, I wonder if:

- Maybe this WISDEM API file is owned by the WISDEM repository.  That would aid in us just using ORBIT as a library
- There was a schema that checked the config-dictionary and provided warnings for unused entries.  What do you think?