### PR TITLE
Cost Updates, Cost Benchmarking Project 

### DIFF
--- a/ORBIT/core/defaults/common_costs.yaml
+++ b/ORBIT/core/defaults/common_costs.yaml
@@ -1,17 +1,19 @@
 # Material costs
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 monopile_design:
-  monopile_steel_cost: 3000                     # USD/t
-  tp_steel_cost: 3000                           # USD/t
+  monopile_steel_cost: 3655                     # USD/t
+  tp_steel_cost: 9821                           # USD/t
 
 # Port properties
-port_cost_per_month: 2e6                      # USD/month
+port_cost_per_month: 2545872                    # USD/month
 
 # Export system component cost rates
 export_system_design:
   cable_crossings:
-    crossing_unit_cost: 500000
+    crossing_unit_cost: 622755   
 
-# Spar component cost rates
+# Spar component cost rates (to be deprecated)
 spar_design:
   stiffened_column_CR: 3120                     # USD/t
   tapered_column_CR: 4220                       # USD/t
@@ -20,53 +22,53 @@ spar_design:
 
 # Offshore substation component cost rates
 substation_design:
-  mpt_cost_rate: 12500                          # USD/MW
-  topside_fab_cost_rate: 14500                  # USD/t
+  mpt_cost_rate: 17145                          # USD/MW
+  topside_fab_cost_rate: 19889                  # USD/t
   topside_design_cost:                          # USD
     #oldHVAC: 4.5e6
-    HVAC: 107.3e6
-    HVDC-monopole: 294e6
-    HVDC-bipole: 476e6
-  shunt_cost_rate: 35000                        # USD/MW
-  mpt_unit_cost: 2.87e6                         # USD/mpt
-  shunt_unit_cost: 10000                        # USD/cable
-  switchgear_cost: 4e6                          # USD/cable
-  dc_breaker_cost: 10.5e6                       # USD/cable
-  backup_gen_cost: 1e6                          # USD
-  workspace_cost: 2e6                           # USD
-  other_ancillary_cost: 3e6                     # USD
+    HVAC: 164745695   
+    HVDC-monopole: 451400132   
+    HVDC-bipole: 730838310   
+  shunt_cost_rate: 48007                        # USD/MW
+  mpt_unit_cost: 4406525                        # USD/mpt
+  shunt_unit_cost: 15354                        # USD/cable
+  switchgear_cost: 6141498                      # USD/cable
+  dc_breaker_cost: 16121433                     # USD/cable
+  backup_gen_cost: 1371635                      # USD
+  workspace_cost: 2743270                       # USD
+  other_ancillary_cost: 4114905                 # USD
   topside_assembly_factor: 0.075                # %
   converter_cost:                               # USD
-    HVAC: 0
-    HVDC-monopole: 127e6
-    HVDC-bipole: 296e6
-  oss_substructure_cost_rate: 3000              # USD/t
+    HVAC: 0   
+    HVDC-monopole: 194992574   
+    HVDC-bipole: 454470882   
+  oss_substructure_cost_rate: 4115              # USD/t
   oss_pile_cost_rate: 0                         # USD/t
 
 # Onshore substation component cost rates
 onshore_substation_design:
   onshore_converter_cost:                       # USD
     HVAC: 0
-    HVDC-monopole: 157e6
-    HVDC-bipole: 350e6
-  shunt_unit_cost: 13000                        # USD/cable
-  switchgear_cost: 9.33e6                       # USD/cable
+    HVDC-monopole: 241053812   
+    HVDC-bipole: 537381110   
+  shunt_unit_cost: 19960                        # USD/cable
+  switchgear_cost: 14325045                     # USD/cable
   compensation_rate:                            # USD/cable
-    HVAC: 31.3e6
-    HVDC-monopole: 0
-    HVDC-bipole: 0
+    HVAC: 48057225  
+    HVDC-monopole: 0   
+    HVDC-bipole: 0  
   onshore_construction_rate:                    # USD
-    HVAC: 5e6
-    HVDC-monopole: 87.3e6
-    HVDC-bipole: 100e6
+    HVAC: 7676873  
+    HVDC-monopole: 134038203  
+    HVDC-bipole: 153537460  
 
 # Semisubmersible component cost rates
 semisubmersible_design:
-  stiffened_column_CR: 3120                     # USD/t
-  truss_CR: 6250                                # USD/t
-  heave_plate_CR: 6250                          # USD/t
-  secondary_steel_CR: 7250                      # USD/t
+  stiffened_column_CR: 4280                     # USD/t
+  truss_CR: 8573                                # USD/t
+  heave_plate_CR: 8573                          # USD/t
+  secondary_steel_CR: 9944                      # USD/t
 
 # Mooring system component cost rates
 mooring_system_design:                          # USD/m
-  mooring_line_cost_rate: [399.0, 721.0, 1088.0]
+  mooring_line_cost_rate: [547.0, 989.0, 1492.0]

--- a/ORBIT/core/defaults/costs_by_procurement_year.csv
+++ b/ORBIT/core/defaults/costs_by_procurement_year.csv
@@ -1,0 +1,79 @@
+﻿Class,Attribute Name,Units (in 2023 USD),2019,2020,2021,2022,2023
+MonopileDesign,monopile_steel_cost,USD/t,3183,2959,4187,4238,3655
+MonopileDesign,tp_steel_cost,USD/t,8553,7952,11251,11388,9821
+SemiSubmersibleDesign,stiffened_column_CR,USD/t,3624,3343,4919,5009,4280
+SemiSubmersibleDesign,truss_CR,USD/t,7260,6697,9854,10034,8573
+SemiSubmersibleDesign,heave_plate_CR,USD/t,7260,6697,9854,10034,8573
+SemiSubmersibleDesign,secondary_steel_CR,USD/t,8421,7768,11430,11640,9944
+SemiSubmersibleDesign,steel_CR,USD/t,3609,3379,4639,4685,4084
+MooringSystemDesign,mooring_line_cost_rate (low),USD/m,463,428,629,641,547
+MooringSystemDesign,mooring_line_cost_rate (mid),USD/m,837,773,1137,1158,989
+MooringSystemDesign,mooring_line_cost_rate (high),USD/m,1264,1166,1715,1747,1492
+ExportSystemDesign,crossing_unit_cost,USD,571328,577659,719474,654810,622755
+calc_onshore_cost,shunt_unit_cost,USD/cable,16700,15305,23104,23566,19960
+calc_onshore_cost,switchgear_cost,USD/cable,11985785,10984324,16581812,16913007,14325045
+calc_onshore_cost,compensation_rate,USD/cable,40209548,36849877,55628158,56739241,48057225
+calc_onshore_cost,onshore_converter_cost (HVAC),USD,0,0,0,0,0
+calc_onshore_cost,onshore_converter_cost (HVDC-monopole),USD,201690066,184838039,279029417,284602584,241053812
+calc_onshore_cost,onshore_converter_cost (HVDC-bipole),USD,449627536,412059323,622040101,634464359,537381110
+calc_onshore_cost,onshore_construction_rate (HVAC),USD,6423251,5886562,8886287,9063777,7676873
+calc_onshore_cost,onshore_construction_rate (HVDC-monopole),USD,112149954,102779368,155154574,158253539,134038203
+calc_onshore_cost,onshore_construction_rate (HVDC-bipole),USD,128465010,117731235,177725743,181275531,153537460
+SubstationDesign,mpt_cost_rate,USD/MW,14519,13393,19707,20069,17145
+SubstationDesign,topside_fab_cost_rate,USD/t,16842,15536,22861,23280,19889
+SubstationDesign,topside_design_cost (HVAC),USD,137842956,126325615,190699723,194508645,164745695
+SubstationDesign,topside_design_cost (HVDC-monopole),USD,377687130,346129831,522513685,532950062,451400132
+SubstationDesign,topside_design_cost (HVDC-bipole),USD,611493448,560400680,845974538,862871528,730838310
+SubstationDesign,shunt_cost_rate,USD/MW,40654,37501,55181,56192,48007
+SubstationDesign,mpt_unit_cost,USD/mpt,3686946,3378886,5100729,5202608,4406525
+SubstationDesign,shunt_unit_cost,USD/cable,12847,11773,17773,18128,15354
+SubstationDesign,switchgear_cost,USD/cable,5138600,4709249,7109030,7251021,6141498
+SubstationDesign,dc_breaker_cost,USD/cable,13488826,12361780,18661203,19033931,16121433
+SubstationDesign,backup_gen_cost,USD,1161544,1071455,1576589,1605487,1371635
+SubstationDesign,workspace_cost,USD,2323088,2142909,3153178,3210975,2743270
+SubstationDesign,other_ancillary_cost,USD,3484632,3214364,4729767,4816462,4114905
+SubstationDesign,converter_cost (HVAC),USD,0,0,0,0,0
+SubstationDesign,converter_cost (HVDC-monopole),USD,163150563,149518669,225711694,230219925,194992574
+SubstationDesign,converter_cost (HVDC-bipole),USD,380256430,348484456,526068200,536575572,454470882
+SubstationDesign,oss_substructure_cost_rate,USD/t,3485,3214,4730,4816,4115
+SubstationDesign,oss_pile_cost_rate,USD/t,0,0,0,0,0
+Cables,HVDC_2000mm_320kV.yaml,USD/km,838059,846067,1040115,946500,900000
+Cables,HVDC_2000mm_320kV_dynamic.yaml,USD/km,919473,928370,1133958,1034500,985602
+Cables,HVDC_2000mm_400kV.yaml,USD/km,721980,729934,916314,831636,789204
+Cables,HVDC_2500mm_525kV.yaml,USD/km,1314062,1326776,1620592,1478452,1408570
+Cables,XLPE_1000m_220kV_dynamic.yaml,USD/km,1407307,1423895,1815796,1642898,1555413
+Cables,XLPE_1000mm_220kV.yaml,USD/km,1314062,1326776,1620592,1478452,1408570
+Cables,XLPE_1200mm_220kV.yaml,USD/km,1314062,1326776,1620592,1478452,1408570
+Cables,XLPE_1000mm_220kV_dynamic.yaml,USD/km,1573172,1588394,1940146,1769978,1686316
+Cables,XLPE_1200mm_275kV.yaml,USD/km,1203014,1214654,1483641,1353512,1289536
+Cables,XLPE_1600mm_275kV.yaml,USD/km,1388093,1401524,1711893,1561745,1487926
+Cables,XLPE_185mm_66kV.yaml,USD/km,238367,241031,302857,274909,260914
+Cables,XLPE_185mm_66kV_dynamic.yaml,USD/km,286041,289237,363428,329891,313097
+Cables,XLPE_1900mm_275kV.yaml,USD/km,1184506,1195967,1460816,1332689,1269697
+Cables,XLPE_400mm_33kV.yaml,USD/km,342797,346595,431685,392886,373653
+Cables,XLPE_500mm_132kV.yaml,USD/km,462698,467175,570631,520582,495975
+Cables,XLPE_500mm_132kV_dynamic.yaml,USD/km,555237,560610,684757,624698,595170
+Cables,XLPE_500mm_220kV.yaml,USD/km,774382,782913,982821,891997,846485
+Cables,XLPE_630mm_220kV.yaml,USD/km,826784,835892,1049327,952357,903766
+Cables,XLPE_630mm_33kV.yaml,USD/km,514195,519893,647527,589329,560479
+Cables,XLPE_630mm_66kV.yaml,USD/km,476734,482061,605714,549818,521828
+Cables,XLPE_630mm_66kV_dynamic.yaml,USD/km,572081,578474,726856,659781,626194
+Cables,XLPE_800mm_220kV.yaml,USD/km,903640,913594,1146870,1040886,987778
+Vessels,example_ahts_vessel.yaml,USD/day,94718,89991,94538,104116,98016
+Vessels,example_cable_lay_vessel.yaml,USD/day,213115,202480,212711,234262,220537
+Vessels,example_feeder.yaml,USD/day,89254,82657,89391,102845,94586
+Vessels,example_heavy_feeder.yaml,USD/day,143020,131404,143203,166504,151966
+Vessels,example_heavy_lift_vessel.yaml,USD/day,595026,551047,595941,685632,630573
+Vessels,example_scour_protection_vessel.yaml,USD/day,142806,132251,143026,164552,151337
+Vessels,example_support_vessel.yaml,USD/day,119184,109503,119336,138754,126639
+Vessels,example_towing_vessel.yaml,USD/day,33151,31497,33088,36441,34306
+Vessels,example_wtiv.yaml,USD/day,214209,198377,214539,246828,227006
+Vessels,floating_barge.yaml,USD/day,143020,131404,143203,166504,151966
+Vessels,floating_heavy_lift_vessel.yaml,USD/day,595918,547516,596679,693768,633193
+Vessels,future_feeder.yaml,USD/day,119184,109503,119336,138754,126639
+Ports,port_cost_per_month,USD/month,2386861,2304938,2569631,2699981,2545872
+Turbine,turbine_capex,,1629,1595,1720,1770,1697
+Project Parameters,site_auction_price,USD,119183549,114641204,128822542,135847863,127433730
+Project Parameters,site_assessment_cost,USD,59591775,57320602,64411271,67923932,63716865
+Project Parameters,construction_plan_cost,USD,1191835,1146412,1288225,1358479,1274337
+Project Parameters,installation_plan_cost,USD,297959,286603,322056,339620,318584

--- a/ORBIT/manager.py
+++ b/ORBIT/manager.py
@@ -1775,13 +1775,13 @@ class ProjectManager:
         the keys below should be passed to the 'project_parameters' subdict.
         """
 
-        site_auction = self.project_params.get("site_auction_price", 100e6)
-        site_assessment = self.project_params.get("site_assessment_cost", 50e6)
+        site_auction = self.project_params.get("site_auction_price", 127433730)
+        site_assessment = self.project_params.get("site_assessment_cost", 63716865)
         construction_plan = self.project_params.get(
-            "construction_plan_cost", 1e6
+            "construction_plan_cost", 1274337
         )
         installation_plan = self.project_params.get(
-            "installation_plan_cost", 0.25e6
+            "installation_plan_cost", 318584
         )
 
         return sum(

--- a/library/cables/HVDC_2000mm_320kV.yaml
+++ b/library/cables/HVDC_2000mm_320kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0           # ohm/km
 capacitance: 295000        # nF/km
 conductor_size: 2000       # mm^2
-cost_per_km: 828000        # $
+cost_per_km: 900000        # $
 current_capacity: 1900     # A # ESTIMATE
 inductance: 0.127          # mH/km
 linear_density: 53         # t/km

--- a/library/cables/HVDC_2000mm_320kV_dynamic.yaml
+++ b/library/cables/HVDC_2000mm_320kV_dynamic.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0           # ohm/km
 capacitance: 295000        # nF/km
 conductor_size: 2000       # mm^2
-cost_per_km: 993600        # $ 20% cost increase
+cost_per_km: 985602        # $ 20% cost increase
 current_capacity: 1900     # A # ESTIMATE
 inductance: 0.127          # mH/km
 linear_density: 53         # t/km

--- a/library/cables/HVDC_2000mm_400kV.yaml
+++ b/library/cables/HVDC_2000mm_400kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0           # ohm/km
 capacitance: 255000        # nF/km
 conductor_size: 2000       # mm^2
-cost_per_km: 620000        # $
+cost_per_km: 789204        # $
 current_capacity: 1900     # A
 inductance: 0.141          # mH/km
 linear_density: 59         # t/km

--- a/library/cables/HVDC_2500mm_525kV.yaml
+++ b/library/cables/HVDC_2500mm_525kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0           # ohm/km
 capacitance: 227000        # nF/km
 conductor_size: 2500       # mm^2
-cost_per_km: 1420000       # $
+cost_per_km: 1408570       # $
 current_capacity: 1905     # A
 inductance: 0.149          # mH/km
 linear_density: 74         # t/km

--- a/library/cables/XLPE_1000mm_220kV.yaml
+++ b/library/cables/XLPE_1000mm_220kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.16        # ohm/km
 capacitance: 190           # nF/km
 conductor_size: 1000       # mm^2
-cost_per_km: 1420000       # $
+cost_per_km: 1408570       # $
 current_capacity: 825      # A
 inductance: 0.38           # mH/km
 linear_density: 115        # t/km

--- a/library/cables/XLPE_1000mm_220kV_dynamic.yaml
+++ b/library/cables/XLPE_1000mm_220kV_dynamic.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.16        # ohm/km
 capacitance: 190           # nF/km
 conductor_size: 1000       # mm^2
-cost_per_km: 1700000       # $ 20% cost increase
+cost_per_km: 1686316       # $ 20% cost increase
 current_capacity: 825      # A
 inductance: 0.38           # mH/km
 linear_density: 115        # t/km

--- a/library/cables/XLPE_1200mm_220kV.yaml
+++ b/library/cables/XLPE_1200mm_220kV.yaml
@@ -1,3 +1,6 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
+
 # Data from this cable type was adjusted to 
 # meet cable capacity of 400 MW seen in the 
 # industry. Data does not come from a data
@@ -5,7 +8,7 @@
 ac_resistance: 0.16        # ohm/km
 capacitance: 190           # nF/km
 conductor_size: 1000       # mm^2
-cost_per_km: 1420000       # $
+cost_per_km: 1408570       # $
 current_capacity: 1050      # A
 inductance: 0.38           # mH/km
 linear_density: 115        # t/km

--- a/library/cables/XLPE_1200mm_220kV.yaml
+++ b/library/cables/XLPE_1200mm_220kV.yaml
@@ -1,0 +1,14 @@
+# Data from this cable type was adjusted to 
+# meet cable capacity of 400 MW seen in the 
+# industry. Data does not come from a data
+# sheet from a cable manufacturer
+ac_resistance: 0.16        # ohm/km
+capacitance: 190           # nF/km
+conductor_size: 1000       # mm^2
+cost_per_km: 1420000       # $
+current_capacity: 1050      # A
+inductance: 0.38           # mH/km
+linear_density: 115        # t/km
+rated_voltage: 220         # kV
+cable_type: HVAC           # HVDC vs HVAC
+name: XLPE_1000m_220kV

--- a/library/cables/XLPE_1200mm_275kV.yaml
+++ b/library/cables/XLPE_1200mm_275kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.026    # ohm/km
 capacitance: 196        # nF/km
 conductor_size: 1200    # mm^2
-cost_per_km: 1300000    # $
+cost_per_km: 1289536    # $
 current_capacity: 547   # A # ESTIMATE
 inductance: 0.37        # mH/km
 linear_density: 148     # t/km

--- a/library/cables/XLPE_1600mm_275kV.yaml
+++ b/library/cables/XLPE_1600mm_275kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.022    # ohm/km
 capacitance: 221        # nF/km
 conductor_size: 1600    # mm^2
-cost_per_km: 1500000    # $
+cost_per_km: 1487926    # $
 current_capacity: 730   # A # ESTIMATE
 inductance: 0.35        # mH/km
 linear_density: 176     # t/km

--- a/library/cables/XLPE_185mm_66kV.yaml
+++ b/library/cables/XLPE_185mm_66kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.128    #
 capacitance: 163        #
 conductor_size: 185     #
-cost_per_km: 200000     #
+cost_per_km: 260914     #
 current_capacity: 445   # At 2m burial depth
 inductance: 0.443       #
 linear_density: 26.1    #

--- a/library/cables/XLPE_185mm_66kV_dynamic.yaml
+++ b/library/cables/XLPE_185mm_66kV_dynamic.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.128    #
 capacitance: 163        #
 conductor_size: 185     #
-cost_per_km: 240000     # $ (20% adder over XLPE_185mm_66kV)
+cost_per_km: 313097     # $ (20% adder over XLPE_185mm_66kV)
 current_capacity: 445   # At 2m burial depth
 inductance: 0.443       #
 linear_density: 26.1    #

--- a/library/cables/XLPE_1900mm_275kV.yaml
+++ b/library/cables/XLPE_1900mm_275kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.020    # ohm/km
 capacitance: 224        # nF/km
 conductor_size: 1900    # mm^2
-cost_per_km: 1280000    # $
+cost_per_km: 1269697    # $
 current_capacity: 910   # A # ESTIMATE
 inductance: 0.35        # mH/km
 linear_density: 185     # t/km

--- a/library/cables/XLPE_400mm_33kV.yaml
+++ b/library/cables/XLPE_400mm_33kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.06
 capacitance: 225
 conductor_size: 400
-cost_per_km: 300000
+cost_per_km: 373653
 current_capacity: 600
 inductance: 0.375
 linear_density: 35

--- a/library/cables/XLPE_500mm_132kV.yaml
+++ b/library/cables/XLPE_500mm_132kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.06
 capacitance: 200
 conductor_size: 500
-cost_per_km: 500000
+cost_per_km: 495975
 current_capacity: 625
 inductance: 0.4
 linear_density: 50

--- a/library/cables/XLPE_500mm_132kV_dynamic.yaml
+++ b/library/cables/XLPE_500mm_132kV_dynamic.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.06
 capacitance: 200
 conductor_size: 500
-cost_per_km: 600000     # $ (20% adder over XLPE_500mm_132kV)
+cost_per_km: 595170     # $ (20% adder over XLPE_500mm_132kV)
 current_capacity: 625
 inductance: 0.4
 linear_density: 50

--- a/library/cables/XLPE_500mm_220kV.yaml
+++ b/library/cables/XLPE_500mm_220kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.03        # ohm/km
 capacitance: 140           # nF/km
 conductor_size: 500        # mm^2
-cost_per_km: 665000        # $
+cost_per_km: 846485        # $
 current_capacity: 655      # A
 inductance: 0.43           # mH/km
 linear_density: 90         # t/km

--- a/library/cables/XLPE_630mm_220kV.yaml
+++ b/library/cables/XLPE_630mm_220kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.25        # ohm/km
 capacitance: 160           # nF/km
 conductor_size: 630        # mm^2
-cost_per_km: 710000        # $
+cost_per_km: 903766        # $
 current_capacity: 715      # A
 inductance: 0.41           # mH/km
 linear_density: 96         # t/km

--- a/library/cables/XLPE_630mm_33kV.yaml
+++ b/library/cables/XLPE_630mm_33kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.04
 capacitance: 300
 conductor_size: 630
-cost_per_km: 450000
+cost_per_km: 560479
 current_capacity: 700
 inductance: 0.35
 linear_density: 42.5

--- a/library/cables/XLPE_630mm_66kV.yaml
+++ b/library/cables/XLPE_630mm_66kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.04
 capacitance: 300
 conductor_size: 630
-cost_per_km: 400000
+cost_per_km: 521828
 current_capacity: 775
 inductance: 0.35
 linear_density: 42.5

--- a/library/cables/XLPE_630mm_66kV_dynamic.yaml
+++ b/library/cables/XLPE_630mm_66kV_dynamic.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.04
 capacitance: 300
 conductor_size: 630
-cost_per_km: 480000       # $  (20% adder over XLPE_630mm_66kV)
+cost_per_km: 626194       # $  (20% adder over XLPE_630mm_66kV)
 current_capacity: 775
 inductance: 0.35
 linear_density: 42.5

--- a/library/cables/XLPE_800mm_220kV.yaml
+++ b/library/cables/XLPE_800mm_220kV.yaml
@@ -1,7 +1,9 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 ac_resistance: 0.20        # ohm/km
 capacitance: 170           # nF/km
 conductor_size: 800        # mm^2
-cost_per_km: 776000        # $
+cost_per_km: 987778        # $
 current_capacity: 775      # A
 inductance: 0.40           # mH/km
 linear_density: 105        # t/km

--- a/library/vessels/example_ahts_vessel.yaml
+++ b/library/vessels/example_ahts_vessel.yaml
@@ -1,6 +1,8 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 transport_specs:
   max_waveheight: 3.0       # m
   max_windspeed: 15         # m/s
-  transit_speed: 14          # km/h
+  transit_speed: 14         # km/h
 vessel_specs:
-  day_rate: 100000          # USD/day
+  day_rate:  98016          # USD/day

--- a/library/vessels/example_cable_lay_vessel.yaml
+++ b/library/vessels/example_cable_lay_vessel.yaml
@@ -1,9 +1,11 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 transport_specs:
   max_waveheight: 2.0   # m
   max_windspeed: 25     # m/s
   transit_speed: 11.5   # km/hr
 vessel_specs:
-  day_rate: 225000      # USD/day, cost of operating vessel with crew
+  day_rate: 220537      # USD/day, cost of operating vessel with crew
   min_draft: 8.5       # m
   overall_length: 171.0  # m
   cable_lay_bury_speed: 0.0625 # km/hr

--- a/library/vessels/example_feeder.yaml
+++ b/library/vessels/example_feeder.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_lift: 500             # t
 jacksys_specs:
@@ -15,4 +17,4 @@ transport_specs:
   max_windspeed: 20         # m/s
   transit_speed: 6          # km/h
 vessel_specs:
-  day_rate: 75000           # USD/day
+  day_rate: 94586           # USD/day

--- a/library/vessels/example_heavy_feeder.yaml
+++ b/library/vessels/example_heavy_feeder.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_lift: 500             # t
 jacksys_specs:
@@ -15,4 +17,4 @@ transport_specs:
   max_windspeed: 20         # m/s
   transit_speed: 6          # km/h
 vessel_specs:
-  day_rate: 120000          # USD/day
+  day_rate: 151966          # USD/day

--- a/library/vessels/example_heavy_lift_vessel.yaml
+++ b/library/vessels/example_heavy_lift_vessel.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_hook_height: 72       # m
   max_lift: 5500            # t
@@ -17,4 +19,4 @@ transport_specs:
   max_windspeed: 20         # m/s
   transit_speed: 7          # km/h
 vessel_specs:
-  day_rate: 500000          # USD/day
+  day_rate: 630573          # USD/day

--- a/library/vessels/example_scour_protection_vessel.yaml
+++ b/library/vessels/example_scour_protection_vessel.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 storage_specs:
   max_cargo: 10000       # t
   max_deck_load: 8      # t/m^2
@@ -7,4 +9,4 @@ transport_specs:
   max_windspeed: 20     # m/s
   transit_speed: 6      # km/hr
 vessel_specs:
-  day_rate: 120000      # USD/day
+  day_rate: 151337      # USD/day

--- a/library/vessels/example_support_vessel.yaml
+++ b/library/vessels/example_support_vessel.yaml
@@ -1,9 +1,11 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 transport_specs:
   max_waveheight: 3       # m
   max_windspeed: 20       # m/s
   transit_speed: 10       # km/h
 vessel_specs:
-  day_rate: 100000        # USD/day
+  day_rate: 126639        # USD/day
   overall_length: 150     # m
   mobilization_days: 7    # days
   mobilization_mult: 1   # Mobilization multiplier applied to 'day_rate'

--- a/library/vessels/example_towing_vessel.yaml
+++ b/library/vessels/example_towing_vessel.yaml
@@ -1,6 +1,8 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 transport_specs:
   max_waveheight: 3.0       # m
   max_windspeed: 15         # m/s
   transit_speed: 14          # km/h
 vessel_specs:
-  day_rate: 35000           # USD/day
+  day_rate: 34306           # USD/day

--- a/library/vessels/example_wtiv.yaml
+++ b/library/vessels/example_wtiv.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_hook_height: 100    # m
   max_lift: 1200          # t
@@ -17,6 +19,6 @@ transport_specs:
   max_windspeed: 20       # m/s
   transit_speed: 10       # km/h
 vessel_specs:
-  day_rate: 180000        # USD/day
+  day_rate: 227006        # USD/day
   mobilization_days: 7    # days
   mobilization_mult: 1  # Mobilization multiplier applied to 'day_rate'

--- a/library/vessels/floating_barge.yaml
+++ b/library/vessels/floating_barge.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_lift: 500             # t
 dynamic_positioning_specs:
@@ -11,4 +13,4 @@ transport_specs:
   max_windspeed: 20         # m/s
   transit_speed: 6          # km/h
 vessel_specs:
-  day_rate: 120000          # USD/day
+  day_rate: 151966          # USD/day

--- a/library/vessels/floating_heavy_lift_vessel.yaml
+++ b/library/vessels/floating_heavy_lift_vessel.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_hook_height: 72       # m
   max_lift: 5500            # t
@@ -13,4 +15,4 @@ transport_specs:
   max_windspeed: 20         # m/s
   transit_speed: 7          # km/h
 vessel_specs:
-  day_rate: 500000          # USD/day
+  day_rate: 633193          # USD/day

--- a/library/vessels/future_feeder.yaml
+++ b/library/vessels/future_feeder.yaml
@@ -1,3 +1,5 @@
+# costs are representative of procurement in 2023 in 2023 USD
+# costs for other years of procurement at ORBIT/core/defaults
 crane_specs:
   max_lift: 500
 jacksys_specs:
@@ -15,4 +17,4 @@ transport_specs:
   max_windspeed: 20
   transit_speed: 6
 vessel_specs:
-  day_rate: 100000
+  day_rate: 126639

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -116,7 +116,7 @@ def test_calc_topside_mass_and_cost():
     assert elect._outputs["num_substations"] == 1
     assert elect._outputs["offshore_substation_topside"][
         "unit_cost"
-    ] == pytest.approx(23683541, abs=1e2)
+    ] == pytest.approx(35301706.75331514, abs=1e2)
 
     mono_dc = deepcopy(base)
     mono_dc["export_system_design"]["cables"] = "HVDC_2000mm_320kV"
@@ -273,7 +273,7 @@ def test_hvac_substation():
     hvac = ElectricalDesign(config)
     hvac.run()
 
-    assert hvac.total_substation_cost == pytest.approx(134448256, abs=1e0)
+    assert hvac.total_substation_cost == pytest.approx(204635144.32577527, abs=1e0)
 
 
 def test_hvdc_substation():
@@ -312,7 +312,7 @@ def test_onshore_substation():
     elect = ElectricalDesign(config)
     elect.run()
     assert elect.onshore_compensation_cost != 0.0
-    assert elect.onshore_cost == pytest.approx(95.487e6, abs=1e2)  # 109.32e6
+    assert elect.onshore_cost == pytest.approx(146608462.86369252, abs=1e2)  # 109.32e6
 
     config_mono = deepcopy(config)
     config_mono["export_system_design"] = {"cables": "HVDC_2000mm_320kV"}

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -282,7 +282,7 @@ def test_hvdc_substation():
     elect = ElectricalDesign(config)
     elect.run()
 
-    assert elect.total_substation_cost == pytest.approx(451924714, abs=1e0)
+    assert elect.total_substation_cost == pytest.approx(692080360.22246, abs=1e0)
 
     assert elect.converter_cost != 0
     assert elect.shunt_reactor_cost == 0
@@ -319,7 +319,7 @@ def test_onshore_substation():
     o_monelect = ElectricalDesign(config_mono)
     o_monelect.run()
     assert o_monelect.onshore_compensation_cost == 0.0
-    assert o_monelect.onshore_cost == 244.3e6
+    assert o_monelect.onshore_cost == 375092015
 
     config_bi = deepcopy(config)
     config_bi["export_system_design"] = {"cables": "HVDC_2500mm_525kV"}

--- a/tests/phases/design/test_electrical_design.py
+++ b/tests/phases/design/test_electrical_design.py
@@ -297,7 +297,7 @@ def test_hvdc_substation():
     elect = ElectricalDesign(config)
     elect.run()
 
-    assert elect.total_substation_cost == pytest.approx(802924714, abs=1e0)
+    assert elect.total_substation_cost == pytest.approx(1230996846.2224603, abs=1e0)
 
     assert elect.converter_cost != 0
     assert elect.shunt_reactor_cost == 0
@@ -326,7 +326,7 @@ def test_onshore_substation():
     o_bi = ElectricalDesign(config_bi)
     o_bi.run()
     assert o_bi.onshore_compensation_cost == 0.0
-    assert o_bi.onshore_cost == 450e6
+    assert o_bi.onshore_cost == 690918570
 
 
 # EXPORT CABLE TESTING

--- a/tests/phases/design/test_monopile_design.py
+++ b/tests/phases/design/test_monopile_design.py
@@ -127,4 +127,4 @@ def test_total_cost():
 
     print(mono.total_cost)
 
-    assert mono.total_cost == pytest.approx(68833066, abs=1e0)
+    assert mono.total_cost == pytest.approx(116810975.33345953, abs=1e0)

--- a/tests/phases/design/test_mooring_system_design.py
+++ b/tests/phases/design/test_mooring_system_design.py
@@ -77,7 +77,7 @@ def test_catenary_mooring_system_kwargs():
 
     base_cost = moor.detailed_output["system_cost"]
 
-    assert base_cost == pytest.approx(76173891, abs=1e0)
+    assert base_cost == pytest.approx(92713564.63161309, abs=1e0)
 
     for k, v in test_kwargs.items():
         config = deepcopy(base)
@@ -137,7 +137,7 @@ def test_tlp_mooring_system_kwargs():
 
     base_cost = moor.detailed_output["system_cost"]
 
-    assert base_cost == pytest.approx(57633231, abs=1e0)
+    assert base_cost == pytest.approx(67281231.8316131, abs=1e0)
 
     for k, v in test_kwargs.items():
         config = deepcopy(tlp_base)

--- a/tests/phases/design/test_oss_design.py
+++ b/tests/phases/design/test_oss_design.py
@@ -49,7 +49,7 @@ def test_parameter_sweep(depth, num_turbines, turbine_rating):
     assert 200 <= o._outputs["offshore_substation_topside"]["mass"] <= 5000
 
     # Check valid substation cost
-    assert 1e6 <= o.total_cost <= 300e6
+    assert 1e6 <= o.total_cost <= 350e6
 
 
 def test_oss_kwargs():
@@ -93,4 +93,4 @@ def test_total_cost():
     oss = OffshoreSubstationDesign(base)
     oss.run()
 
-    assert oss.total_cost == pytest.approx(158022050, abs=1e0)
+    assert oss.total_cost == pytest.approx(235726330.7, abs=1e0)

--- a/tests/phases/design/test_semisubmersible_design.py
+++ b/tests/phases/design/test_semisubmersible_design.py
@@ -72,4 +72,4 @@ def test_total_cost():
     semi = SemiSubmersibleDesign(base)
     semi.run()
 
-    assert semi.total_cost == pytest.approx(630709636, abs=1e0)
+    assert semi.total_cost == pytest.approx(865146205.62, abs=1e0)

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -995,14 +995,14 @@ def test_total_capex():
     fix_project.run()
 
     assert fix_project.total_capex == pytest.approx(
-        1216449001.7410436, abs=1e-1
+        1508817512.135874, abs=1e-1
     )
 
     flt_project = ProjectManager(complete_floating_project)
     flt_project.run()
 
     assert flt_project.total_capex == pytest.approx(
-        3540761314.148985, abs=1e-1
+        4088776672.8135986, abs=1e-1
     )
 
 

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -995,7 +995,7 @@ def test_total_capex():
     fix_project.run()
 
     assert fix_project.total_capex == pytest.approx(
-        1508817512.135874, abs=1e-1
+        1501890553.6424453, abs=1e-1
     )
 
     flt_project = ProjectManager(complete_floating_project)


### PR DESCRIPTION
**Overview:**
This pull request updates the ORBIT cost data to incorporate the findings from the Cost Benchmarking project, which aimed to enhance the accuracy of offshore wind component cost estimations. As part of this project, we interviewed and surveyed industry partners to understand current offshore wind component costs, and developed a methodology to adjust ORBIT costs based on the year of procurement and fluctuations in commodity prices.

**Changes:**

- Updated ORBIT Costs: All relevant cost data (including defaults, cables, vessels, port fees, etc.) has been updated to reflect the specific procurement year and USD year based on the most recent available data (2023).

- CSV File with Adjusted Costs: A new `.csv` file containing costs for different procurement years, adjusted to 2023 USD, will be added to the repository. This will allow users to manually adjust the procurement year if needed. The file will be located at `ORBIT/core/defaults`.

**Additional Context:**

- The cost data has been updated to align with the latest procurement year (2023) and the latest USD year (2023), ensuring that the cost estimates are as current as possible.

- There is an internal NREL Excel spreadsheet that tracks this data over the years, capturing costs based on varying procurement and USD years. For more detailed information, please contact Daniel.MulasHernando@nrel.gov.