### PR TITLE
Patch: v1.2.2, Replace deprecated NumPy `trapz` method

### DIFF
--- a/ORBIT/__init__.py
+++ b/ORBIT/__init__.py
@@ -17,4 +17,4 @@ from ORBIT.config import load_config, save_config
 from ORBIT.parametric import ParametricManager
 from ORBIT.supply_chain import SupplyChainManager
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/ORBIT/phases/design/_cables.py
+++ b/ORBIT/phases/design/_cables.py
@@ -414,7 +414,7 @@ class CableSystem(DesignPhase):
             )
             return d
 
-        return np.trapz(np.sqrt(1 + np.gradient(y, x) ** 2), x)
+        return np.trapezoid(np.sqrt(1 + np.gradient(y, x) ** 2), x)
 
     @property
     def free_cable_length(self):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,10 @@
 ORBIT Changelog
 ===============
 
+1.2.2
+-----
+- Replaced the deprecated `numpy.trapz` with `numpy.trapezoid`.
+
 1.2.1
 -----
 - Removed `wisdem_api.py` because WISDEM now uses orbit as a pip installed package.


### PR DESCRIPTION
This PR replaces the use of the deprecated`np.trapz` with its renamed `np.trapezoid` function. All tests pass, and the changelog has been updated to indicate the new version.