### PR TITLE
Patch: Enable `create_layout_df` for the `CustomArraySystemDesign`

### DIFF
--- a/ORBIT/__init__.py
+++ b/ORBIT/__init__.py
@@ -17,4 +17,4 @@ from ORBIT.config import load_config, save_config
 from ORBIT.parametric import ParametricManager
 from ORBIT.supply_chain import SupplyChainManager
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/ORBIT/phases/design/array_system_design.py
+++ b/ORBIT/phases/design/array_system_design.py
@@ -7,6 +7,7 @@ __email__ = "rob.hammond@nrel.gov"
 
 
 import warnings
+from copy import deepcopy
 from collections import OrderedDict
 
 import numpy as np
@@ -1129,3 +1130,39 @@ class CustomArraySystemDesign(ArraySystemDesign):
             for name in self.cables
         }
         return cables
+
+    def create_layout_df(self) -> pd.DataFrame:
+        """Creates a Pandas DataFrame layout.
+
+        Returns
+        -------
+        pd.DataFrame
+            The wind farm layout returned back in its original form.
+        """
+        layout_df = deepcopy(self.location_data)
+        substation_cols = [
+            "substation_id",
+            "substation_name",
+            "substation_latitude",
+            "substation_longitude",
+        ]
+        substations = (
+            layout_df[substation_cols]
+            .drop_duplicates()
+            .rename(
+                columns={
+                    col: col.replace("substation_", "")
+                    for col in layout_df.columns
+                }
+            )
+        )
+        layout_df = layout_df.drop(columns=substation_cols).rename(
+            columns={
+                col: col.replace("turbine_", "") for col in layout_df.columns
+            }
+        )
+        layout_df = (
+            pd.concat((layout_df, substations))
+            .reset_index(drop=True)
+            .fillna("")
+        )

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,8 +3,13 @@
 ORBIT Changelog
 ===============
 
-Unreleased
-----------
+1.2.6
+-----
+- Implements `create_layout_df` for the `CustomArraySystemDesign` model to ensure
+  compatibility with workflows relying on the layout generation tools.
+
+1.2.5
+-----
 - Allow for a Pandas DataFrame to be passed directly to the ``CustomArraySystemDesign.layout_data``
   configuration input.
 - Move the matplotlib import from the import section of ``/ORBIT/phases/design/array_system_design.py``


### PR DESCRIPTION
This patch adds a compatible version of the `create_layout_df` for the `CustomArraySystemDesign` for use in workflows where the `create_layout_df` is called regardless of the existence of the `location_data` CSV file.